### PR TITLE
fix: multiple chat model-item width #920

### DIFF
--- a/src/pages/playground/components/multiple-chat/model-item.tsx
+++ b/src/pages/playground/components/multiple-chat/model-item.tsx
@@ -248,7 +248,7 @@ const ModelItem: React.FC<ModelItemProps> = forwardRef((props, ref) => {
       <div className="header">
         <span className="title">
           <BaseSelect
-            style={{ width: '100%' }}
+            style={{ width: '100%', minWidth: 'fit-content' }}
             variant="borderless"
             options={modelFullList}
             onChange={onModelChange}

--- a/src/pages/playground/style/model-item.less
+++ b/src/pages/playground/style/model-item.less
@@ -16,8 +16,9 @@
     width: 100%;
 
     .title {
-      max-width: min(100%, 230px);
+      max-width: max(65%, 230px);
       min-width: min(120px, 32%);
+      flex: 1;
     }
   }
 


### PR DESCRIPTION
* 关键改进： minWidth: 'fit-content': 根据内容自动调整宽度

* 效果 短模型名称：自动收缩，节省空间
长模型名称：自动扩展，完整显示
响应式：根据容器宽度自动调整
用户体验：避免文本被截断，提升可读性

-- powered by AI