### PR TITLE
feat(plugin): expose OrgSwitcher slot in extraRender

### DIFF
--- a/src/layouts/extraRender.tsx
+++ b/src/layouts/extraRender.tsx
@@ -120,6 +120,10 @@ export const ExtraContent = (props: { isDarkTheme?: boolean }) => {
 
   const { initialState } = initialInfo;
   const GlobalSettings = pluginManager?.components?.GlobalSettings;
+  // Plugin slot. A registered plugin can supply an Org switcher via
+  // components.OrgSwitcher; the host renders nothing when no plugin
+  // provides it.
+  const OrgSwitcher = pluginManager?.components?.OrgSwitcher;
   console.log('plugin+++++++++', pluginManager);
 
   const navigate = useNavigate();
@@ -271,6 +275,7 @@ export const ExtraContent = (props: { isDarkTheme?: boolean }) => {
   return (
     <Wrapper>
       {contextHolder}
+      {OrgSwitcher && <OrgSwitcher isDarkTheme={isDarkTheme} />}
       <div
         style={{
           display: 'flex',

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -348,7 +348,22 @@ export default (props: any) => {
         hooks={{
           useUserSettings: useUserSettings,
           useUserSettingsStorage: () => userSettingsStorage,
-          useIntl: useIntl
+          useIntl: useIntl,
+          // Bridge umi's `@@initialState` model so plugins consuming
+          // `useCurrentUser` from @gpustack/core-ui get the signed-in
+          // user without depending on @umijs/max directly. Translate
+          // the host's snake_case fields to core-ui's camelCase
+          // `CurrentUser` shape, but pass everything else through so
+          // hosts can carry extra fields.
+          useCurrentUser: () => {
+            const cu = useModel?.('@@initialState')?.initialState?.currentUser;
+            if (!cu) return undefined;
+            return {
+              ...cu,
+              fullName: cu.full_name ?? cu.fullName,
+              isAdmin: cu.is_admin ?? cu.isAdmin
+            };
+          }
         }}
         i18n={intl}
         locale={{


### PR DESCRIPTION
Add a single host-side mount point in extraRender.tsx.
A registered plugin can supply an Org switcher via components.OrgSwitcher. When no plugin provides it, the host renders nothing here, so the build is visually unchanged.