### PR TITLE
feat: expose useTableFetch via CoreUIProvider

### DIFF
--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -5,6 +5,7 @@ import routeCachekey from '@/config/route-cachekey';
 import { DEFAULT_ENTER_PAGE, GPUSTACK_API_BASE_URL } from '@/config/settings';
 import { COLOR_PRIMARY } from '@/config/theme';
 import useCurrentUser from '@/hooks/use-current-user';
+import useTableFetch from '@/hooks/use-table-fetch';
 import useUserSettings from '@/hooks/use-user-settings';
 import useUserSettingsStorage from '@/hooks/use-user-settings-storage';
 import useAddResource from '@/pages/dashboard/hooks/use-add-resource';
@@ -349,7 +350,8 @@ export default (props: any) => {
           useUserSettings,
           useUserSettingsStorage,
           useIntl,
-          useCurrentUser
+          useCurrentUser,
+          useTableFetch
         }}
         i18n={intl}
         locale={{


### PR DESCRIPTION
Inject the host's `useTableFetch` hook into the CoreUIProvider's `hooks` prop alongside the already-wired `useCurrentUser`, so plugins that import `useTableFetch` from `@gpustack/core-ui` resolve it through the host instead of throwing
"`hooks.useTableFetch is not a function`" at the first list-page render.

Companion to the earlier `feat: add use current user` change — core-ui exposes both hooks as host-injected, but only the user hook had been plumbed.