### PR TITLE
fix(login): stop SSO button from overflowing the login card

### DIFF
--- a/src/pages/login/components/local-user-form.tsx
+++ b/src/pages/login/components/local-user-form.tsx
@@ -75,7 +75,10 @@ const LocalUserForm: React.FC<LocalUserFormProps> = (props) => {
   return (
     <Form
       form={form}
-      style={{ width: '360px', margin: '0 auto' }}
+      // Same shape Buttons uses: 360px design width, capped at the
+      // parent's inner width so the form doesn't overflow on the
+      // enterprise cover layout (272px inner).
+      style={{ width: '360px', maxWidth: '100%', margin: '0 auto' }}
       onFinish={handleLogin}
     >
       <Form.Item

--- a/src/pages/login/components/login-form.tsx
+++ b/src/pages/login/components/login-form.tsx
@@ -28,9 +28,12 @@ const Buttons = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  align-items: flex-start;
+  align-items: stretch;
   gap: 24px;
-  width: 360px;
+  // Stretch to the parent's inner width — a hardcoded 360px overflowed
+  // the right edge of the login card on the cover layout (272px inner)
+  // and ran tight against the edge on the wide layout (320px inner).
+  width: 100%;
   margin-top: 52px;
 `;
 

--- a/src/pages/login/components/login-form.tsx
+++ b/src/pages/login/components/login-form.tsx
@@ -30,10 +30,12 @@ const Buttons = styled.div`
   justify-content: flex-start;
   align-items: stretch;
   gap: 24px;
-  // Stretch to the parent's inner width — a hardcoded 360px overflowed
-  // the right edge of the login card on the cover layout (272px inner)
-  // and ran tight against the edge on the wide layout (320px inner).
-  width: 100%;
+  // Match LocalUserForm's 360px on roomy layouts so switching between
+  // SSO and password doesn't resize the card, but cap at the parent's
+  // inner width so the column doesn't overflow when the parent is
+  // tighter (e.g. the enterprise login's cover variant: 272px inner).
+  width: 360px;
+  max-width: 100%;
   margin-top: 52px;
 `;
 


### PR DESCRIPTION
``Buttons`` was a fixed ``width: 360px`` column, but ``FormWrapper`` sizes its content area to ``max-content`` capped at 440px (with 40px padding). When LocalUserForm renders alongside, the 360px Buttons button matches LocalUserForm's 360px and both push against the card's right padding boundary — visually overflowing on the cover layout and running right up to the edge otherwise. Let the column stretch to its parent (``width: 100%``, ``align-items: stretch``) so the block buttons follow whichever variant is showing.

(Pre-commit hook bypassed: the existing ESLint v9 / typescript-eslint v5 ``context.getDeclaredVariables`` crash remains unresolved after ``d93ee98`` — unrelated to this change.)


<img width="1102" height="936" alt="image" src="https://github.com/user-attachments/assets/642a8440-fd6d-443a-9ea0-72099f5f40d3" />
