### PR TITLE
fix: guard systemConfigAtom reads against null

### DIFF
--- a/src/pages/llmodels/hooks/use-models-columns.tsx
+++ b/src/pages/llmodels/hooks/use-models-columns.tsx
@@ -127,7 +127,7 @@ const useModelsColumns = ({
         return record.replicas > 0;
       }
       if (action.key === 'metrics') {
-        return systemConfig.showMonitoring;
+        return systemConfig?.showMonitoring;
       }
 
       return true;

--- a/src/pages/resources/hooks/use-grafana-link.tsx
+++ b/src/pages/resources/hooks/use-grafana-link.tsx
@@ -10,7 +10,7 @@ const useGranfanaLink = (options: {
 }) => {
   const intl = useIntl();
   const systemConfig = useAtomValue(systemConfigAtom);
-  const grafanaUrl = systemConfig.grafana_url || 'grafana';
+  const grafanaUrl = systemConfig?.grafana_url || 'grafana';
 
   // for worker/model/instance/cluster item entry
   const goToModelGrafana = (row: { id: number }) => {
@@ -55,12 +55,12 @@ const useGranfanaLink = (options: {
 
   // all endpoints of grafana
   const modelEntry = () => {
-    const modelURL = systemConfig.grafana_model_dashboard_uid;
+    const modelURL = systemConfig?.grafana_model_dashboard_uid;
     window.open(`${grafanaUrl}/d/${modelURL}/gpustack-model`, '_blank');
   };
 
   const workerEntry = () => {
-    const workerURL = systemConfig.grafana_worker_dashboard_uid;
+    const workerURL = systemConfig?.grafana_worker_dashboard_uid;
     window.open(`${grafanaUrl}/d/${workerURL}/gpustack-worker`, '_blank');
   };
 

--- a/src/pages/resources/hooks/use-worker-columns.tsx
+++ b/src/pages/resources/hooks/use-worker-columns.tsx
@@ -291,7 +291,7 @@ const useWorkerColumns = ({
       }
 
       if (action.key === 'metrics') {
-        return systemConfig.showMonitoring;
+        return systemConfig?.showMonitoring;
       }
       return true;
     });


### PR DESCRIPTION
``logout`` calls ``clearAtomStorage(systemConfigAtom)`` which sets the atom to ``null``, and on a fresh SPA login (no full reload) ``app.tsx``'s ``fetchSystemConfig`` doesn't re-run, so consumers that read ``systemConfig.xxx`` directly crash with "Cannot read properties of null". A hard refresh masks the bug. Add optional chaining at the read sites (grafana url / dashboard uids, showMonitoring) so the contract stays robust regardless of how the atom is reset.