### PR TITLE
fix: require ref audio for Base task in TTS playground

### DIFF
--- a/src/pages/playground/speech/forms/tts-advance.tsx
+++ b/src/pages/playground/speech/forms/tts-advance.tsx
@@ -55,6 +55,7 @@ const TTSAdvanceConfig: React.FC = () => {
       ref_audio: base64
     });
     setFileName(file.name);
+    form.validateFields(['ref_audio']);
 
     onValuesChange?.(
       { ref_audio: base64 },
@@ -67,6 +68,7 @@ const TTSAdvanceConfig: React.FC = () => {
       ref_audio: ''
     });
     setFileName('');
+    form.validateFields(['ref_audio']);
     onValuesChange?.(
       { ref_audio: '' },
       { ...form.getFieldsValue(), ref_audio: '' }
@@ -137,9 +139,17 @@ const TTSAdvanceConfig: React.FC = () => {
           name="ref_audio"
           getValueProps={(value) => ({ value: fileName ? fileName : value })}
           dependencies={['task_type']}
+          rules={[
+            {
+              required: taskType === 'Base',
+              whitespace: true,
+              message: getRuleMessage('input', 'playground.params.refAudio')
+            }
+          ]}
         >
           <CInput.Input
             allowClear
+            required={taskType === 'Base'}
             readOnly={!!fileName}
             suffix={
               <SuffixWrapper>
@@ -163,12 +173,7 @@ const TTSAdvanceConfig: React.FC = () => {
           ></CInput.Input>
         </Form.Item>
       </Container>
-      <Form.Item
-        name="ref_text"
-        style={{ marginBottom: 12 }}
-        dependencies={['task_type', 'x_vector_only_mode']}
-        rules={[atLeastOneValidator('x_vector_only_mode')]}
-      >
+      <Form.Item name="ref_text" style={{ marginBottom: 12 }}>
         <CInput.TextArea
           allowClear
           scaleSize={true}


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5077


## Summary
- Add non-empty validation for **Reference Audio** when `Task Type` is `Base` in the Text-to-Speech playground.
- Keep the "at least one of ref text / speaker embedding" validator only on `x_vector_only_mode` so the hint no longer renders twice.

Before:
<img width="740" height="614" alt="image" src="https://github.com/user-attachments/assets/8511574e-5b15-434a-9dfa-242e760803cd" />

After:
<img width="754" height="554" alt="image" src="https://github.com/user-attachments/assets/4201a2ae-5a19-4b7a-a50d-1a6dcf4e377f" />
