### PR TITLE
fix(model-routes): use overridden model name for provider targets

### DIFF
--- a/src/pages/maas-provider/hooks/use-register-route.ts
+++ b/src/pages/maas-provider/hooks/use-register-route.ts
@@ -15,9 +15,8 @@ const useRegisterRoute = () => {
       routeTargets: [
         {
           weight: 100,
-          provider_model_name: model.name,
-          provider_id: record.id,
-          parentId: record.id
+          overridden_model_name: model.name,
+          provider_id: record.id
         }
       ]
     };

--- a/src/pages/model-routes/components/route-targets.tsx
+++ b/src/pages/model-routes/components/route-targets.tsx
@@ -68,7 +68,7 @@ const RouteItem: React.FC<TargetItemProps> = ({
         <AutoTooltip ghost minWidth={20}>
           {data.model_id
             ? modelList?.find((m) => m.value === data.model_id)?.label
-            : data.provider_model_name}
+            : data.overridden_model_name}
         </AutoTooltip>
       </span>
     );

--- a/src/pages/model-routes/config/types.ts
+++ b/src/pages/model-routes/config/types.ts
@@ -1,22 +1,21 @@
+export interface RouteTargetFormItem {
+  id?: number;
+  overridden_model_name?: string;
+  weight?: number | null;
+  model_id?: number;
+  provider_id?: number;
+  fallback_status_codes?: string[];
+  parentId?: string | number;
+}
+
 export interface FormData {
   name: string;
   description: string;
   categories: any[];
   meta: Record<string, any>;
   generic_proxy: boolean;
-  fallback_target: {
-    provider_model_name?: string;
-    model_id?: number;
-    provider_id?: number;
-    fallback_status_codes?: string[];
-  };
-  targets: {
-    provider_model_name?: string;
-    weight?: number | null;
-    model_id?: number;
-    provider_id?: number;
-    fallback_status_codes?: string[];
-  }[];
+  fallback_target: RouteTargetFormItem | null;
+  targets: RouteTargetFormItem[];
 }
 
 export interface RouteItem {
@@ -34,7 +33,7 @@ export interface RouteItem {
   access_policy: string;
 }
 
-export interface RouteTarget {
+export interface RouteTarget extends RouteTargetFormItem {
   id: number;
   created_at: string;
   updated_at: string;
@@ -44,7 +43,7 @@ export interface RouteTarget {
   route_name: string;
   route_id: number;
   provider_id: number;
-  provider_model_name: string;
+  overridden_model_name: string;
   fallback_status_codes: string[];
   state: string;
 }

--- a/src/pages/model-routes/forms/index.tsx
+++ b/src/pages/model-routes/forms/index.tsx
@@ -14,10 +14,48 @@ import { Form } from 'antd';
 import _ from 'lodash';
 import { forwardRef, useEffect, useImperativeHandle, useRef } from 'react';
 import FormContext from '../config/form-context';
-import { FormData, RouteItem as ListItem } from '../config/types';
+import {
+  FormData,
+  RouteItem as ListItem,
+  RouteTargetFormItem
+} from '../config/types';
 import useEditTargets from '../hooks/use-edit-targets';
 import Basic from './basic';
 import Targets from './targets';
+
+const isSameTarget = (
+  left?: RouteTargetFormItem | null,
+  right?: RouteTargetFormItem | null
+) => {
+  if (!left || !right) {
+    return false;
+  }
+
+  if (left.model_id != null || right.model_id != null) {
+    return left.model_id != null && left.model_id === right.model_id;
+  }
+
+  return (
+    left.provider_id != null &&
+    left.provider_id === right.provider_id &&
+    left.overridden_model_name === right.overridden_model_name
+  );
+};
+
+const normalizeTarget = (
+  target: RouteTargetFormItem | null | undefined
+): RouteTargetFormItem => {
+  const normalizedTarget = {
+    id: target?.id,
+    weight: target?.weight ?? 0,
+    model_id: target?.model_id,
+    provider_id: target?.provider_id,
+    overridden_model_name: target?.overridden_model_name,
+    fallback_status_codes: target?.fallback_status_codes
+  };
+
+  return _.omitBy(normalizedTarget, _.isUndefined) as RouteTargetFormItem;
+};
 
 interface ProviderFormProps {
   ref?: any;
@@ -25,12 +63,7 @@ interface ProviderFormProps {
   action: PageActionType;
   realAction?: string;
   currentData?: ListItem & {
-    routeTargets?: {
-      weight?: number;
-      model_id?: number;
-      provider_id?: number;
-      provider_model_name?: string;
-    }[];
+    routeTargets?: RouteTargetFormItem[];
   }; // Used when action is EDIT
   onFinish: (values: FormData) => Promise<void>;
   onFallbackChange?: (changed: boolean) => void;
@@ -92,21 +125,12 @@ const AccessForm: React.FC<ProviderFormProps> = forwardRef((props, ref) => {
     const fallbackTarget = values.fallback_target;
 
     if (fallbackTarget) {
-      const exsitinged = targetList.find((ep) => {
-        if (fallbackTarget!.model_id) {
-          return ep.model_id === fallbackTarget!.model_id;
-        }
-        return (
-          ep.provider_id === fallbackTarget!.provider_id &&
-          ep.provider_model_name === fallbackTarget!.provider_model_name
-        );
-      });
-      if (exsitinged) {
+      const existingTarget = targetList.find((target) =>
+        isSameTarget(target, fallbackTarget)
+      );
+      if (existingTarget) {
         targetList = targetList.map((ep) => {
-          if (
-            ep.model_id === fallbackTarget.model_id ||
-            ep.provider_model_name === fallbackTarget.provider_model_name
-          ) {
+          if (isSameTarget(ep, fallbackTarget)) {
             return {
               ...ep,
               fallback_status_codes: ['4xx', '5xx']
@@ -116,7 +140,7 @@ const AccessForm: React.FC<ProviderFormProps> = forwardRef((props, ref) => {
         });
       }
 
-      if (!exsitinged) {
+      if (!existingTarget) {
         targetList.push({
           ...fallbackTarget,
           weight: 0,
@@ -125,7 +149,7 @@ const AccessForm: React.FC<ProviderFormProps> = forwardRef((props, ref) => {
       }
     }
 
-    return targetList;
+    return targetList.map((target) => normalizeTarget(target));
   };
 
   const handleOnFinish = (values: FormData) => {
@@ -144,21 +168,14 @@ const AccessForm: React.FC<ProviderFormProps> = forwardRef((props, ref) => {
       return;
     }
 
-    const initDataList = async (
-      targets: {
-        weight?: number;
-        model_id?: number;
-        provider_id?: number;
-        provider_model_name?: string;
-      }[]
-    ) => {
+    const initDataList = async (targets: RouteTargetFormItem[]) => {
       // init targets form list
       targetsRef.current?.initDataList(
         targets?.map((ep) => ({
           weight: ep.weight,
           value: ep.model_id
             ? ['deployments', ep.model_id]
-            : [ep.provider_id, ep.provider_model_name]
+            : [ep.provider_id, ep.overridden_model_name]
         })) || []
       );
     };
@@ -181,7 +198,7 @@ const AccessForm: React.FC<ProviderFormProps> = forwardRef((props, ref) => {
         targetsRef.current?.initFallbackValues({
           value: fallbackTarget.model_id
             ? ['deployments', fallbackTarget.model_id]
-            : [fallbackTarget.provider_id, fallbackTarget.provider_model_name]
+            : [fallbackTarget.provider_id, fallbackTarget.overridden_model_name]
         });
       }
     };

--- a/src/pages/model-routes/hooks/use-target-source-models.tsx
+++ b/src/pages/model-routes/hooks/use-target-source-models.tsx
@@ -68,7 +68,7 @@ const useTargetSourceModels = () => {
             label: model.name,
             value: model.name,
             data: {
-              provider_model_name: model.name,
+              overridden_model_name: model.name,
               provider_id: provider.id,
               parentId: provider.id
             },


### PR DESCRIPTION
修复创建路由时字段验证问题：
```
1 validation errors:
  {'type': 'value_error', 'loc': ('body', 'targets', 0), 'msg': 'Value error, overridden_model_name must be provided when provider_id is set.', 'input': {'weight': 100, 'provider_model_name': 'bge-m3', 'provider_id': 12, 'parentId': 12}, 'ctx': {'error': ValueError('overridden_model_name must be provided when provider_id is set.')}}
