### PR TITLE
fix: inject X-Organization-Id on non-umi fetch paths

### DIFF
--- a/src/pages/playground/apis/index.ts
+++ b/src/pages/playground/apis/index.ts
@@ -1,5 +1,9 @@
 import { GPUSTACK_API_BASE_URL, OPENAI_COMPATIBLE } from '@/config/settings';
-import { createFormData, errorHandler } from '@/utils/fetch-chunk-data';
+import {
+  createFormData,
+  errorHandler,
+  tenantHeaders
+} from '@/utils/fetch-chunk-data';
 import { request } from '@umijs/max';
 
 export { GPUSTACK_API_BASE_URL, OPENAI_COMPATIBLE };
@@ -92,7 +96,8 @@ export const createImages = async (
     body: JSON.stringify(params),
     signal: options.signal,
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      ...tenantHeaders()
     }
   });
   if (!res.ok) {
@@ -112,7 +117,10 @@ export const editImage = async (params: {
   const response = await fetch(EDIT_IMAGE_API, {
     method: 'POST',
     body: createFormData(params.data),
-    signal: params.signal
+    signal: params.signal,
+    headers: {
+      ...tenantHeaders()
+    }
   });
   if (!response.ok) {
     return await errorHandler(response);
@@ -129,7 +137,8 @@ export const createImage = async (params: {
     body: JSON.stringify(params.data),
     signal: params.signal,
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      ...tenantHeaders()
     }
   });
 
@@ -156,7 +165,8 @@ export const textToSpeech = async (params: any, options?: any) => {
     method: 'POST',
     body: JSON.stringify(params.data),
     headers: {
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      ...tenantHeaders()
     },
     signal: params.signal
   });

--- a/src/utils/fetch-chunk-data.ts
+++ b/src/utils/fetch-chunk-data.ts
@@ -3,6 +3,48 @@ import qs from 'query-string';
 
 const extractStreamRegx = /(data|error):\s*({.*?})(?=\n|$)/g;
 
+const readJsonNumber = (
+  storage: Storage | null,
+  key: string
+): number | null => {
+  if (storage == null) {
+    return null;
+  }
+  try {
+    const raw = storage.getItem(key);
+    if (raw == null) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    return typeof parsed === 'number' ? parsed : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Read the active Org id the same way the umi request interceptor in
+ * ``request.extensions.ts`` does, then translate it to the header the
+ * backend's tenant resolver expects. Lets non-umi ``fetch()`` paths —
+ * streaming Playground completions, raw image / TTS POSTs — pin
+ * tenant context with the same precedence rules as everywhere else
+ * (createScope override first, current org second). Returns an empty
+ * object when no active org context is set.
+ */
+export const tenantHeaders = (): Record<string, string> => {
+  if (typeof window === 'undefined') {
+    return {};
+  }
+  try {
+    const orgId =
+      readJsonNumber(window.sessionStorage, 'createScopeOrgOverride') ??
+      readJsonNumber(window.localStorage, 'currentOrganizationId');
+    return orgId == null ? {} : { 'X-Organization-Id': String(orgId) };
+  } catch {
+    return {};
+  }
+};
+
 const extractJSON = (
   dataStr: string
 ): { results: any[]; remaining: string } => {
@@ -71,7 +113,8 @@ export const fetchChunkedData = async (params: {
     signal: params.signal,
     headers: {
       'Content-Type': 'application/json',
-      ...params.headers
+      ...tenantHeaders(),
+      ...(params.headers || {})
     }
   });
 
@@ -122,7 +165,11 @@ export const fetchChunkedDataPostFormData = async (params: {
   const response = await fetch(url, {
     method: 'POST',
     body: createFormData(params.data),
-    signal: params.signal
+    signal: params.signal,
+    headers: {
+      ...tenantHeaders(),
+      ...(params.headers || {})
+    }
   });
   if (!response.ok) {
     return await errorHandler(response);


### PR DESCRIPTION
Playground completions (chat streaming via ``fetchChunkedData``) and the raw ``fetch()`` calls for image / audio generation skip umi's ``request`` pipeline and so miss the request interceptor in ``request.extensions.ts`` that pins tenant context. Higress receives those calls without ``X-Organization-Id`` and the auth callback falls back to the user's USER-principal id rather than their active Org, which makes Playground usage invisible from Org-scoped Usage views even after the backend learned to backfill ``consumer_principal_id``.

Centralise the lookup in ``tenantHeaders()`` next to ``fetchChunkedData`` so both streaming helpers and the four ``fetch()``-direct entry points in ``playground/apis/index.ts`` (image / TTS) attach the header with the same precedence as the umi interceptor (``createScopeOrgOverride`` first, ``currentOrganizationId`` second). Returns an empty object when no active org context is set, leaving requests unchanged.