### PR TITLE
fix: pick candidate for CPU instance type

### DIFF
--- a/src/pages/gpu-service/instances/config/index.ts
+++ b/src/pages/gpu-service/instances/config/index.ts
@@ -196,7 +196,8 @@ export const getAcceleratorMax = (
 
 // Picks the candidate (cluster + type name) that should fulfill a requested
 // accelerator count: the first candidate of the smallest tier whose
-// onceMaxRequest is >= the requested count.
+// onceMaxRequest is >= the requested count. For CPU types (count === 0)
+// the 0-tier matches and yields the per-cluster candidate.
 export const pickCandidateForAccelerator = <
   C extends { cluster: string; name: string }
 >(
@@ -210,10 +211,11 @@ export const pickCandidateForAccelerator = <
   const sorted = [...tiers].sort(
     (a, b) => parseQuantity(a.onceMaxRequest) - parseQuantity(b.onceMaxRequest)
   );
-  const tier = sorted.find((t) =>
-    count === 0
-      ? parseQuantity(t.onceMaxRequest) > count
-      : parseQuantity(t.onceMaxRequest) >= count
-  );
+  const tier =
+    sorted.find(
+      (t) =>
+        parseQuantity(t.onceMaxRequest) >= count &&
+        (t.candidates?.length ?? 0) > 0
+    ) ?? sorted.find((t) => (t.candidates?.length ?? 0) > 0);
   return tier?.candidates?.[0] ?? null;
 };


### PR DESCRIPTION
For non-acceleratable (CPU) instance types, the picker was called with count=0 and skipped tiers whose onceMaxRequest equals 0, returning null and leaving spec.type empty. Match tiers with onceMaxRequest >= count consistently, with a fallback to any tier that has candidates.