### PR TITLE
fix(routes): let Org owners see Storage Types menu

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -224,7 +224,12 @@ const baseRoutes = [
         path: '/gpu-service/storage-types',
         key: 'gpuServiceStorageTypes',
         icon: 'icon-storage-outlined',
-        access: 'canSeeAdmin',
+        // Storage types are tenant-scoped on the backend (Org owners
+        // can create/list their own), so the menu shouldn't be
+        // platform-admin-only. ``canSeeOrgAdmin`` keeps the gate at
+        // "admin or current-org owner" — Org members still don't see
+        // it, which matches the read/write model in the route.
+        access: 'canSeeOrgAdmin',
         selectedIcon: 'icon-storage-filled',
         defaultIcon: 'icon-storage-outlined',
         component: './gpu-service/storage-types'


### PR DESCRIPTION
The route was gated on ``canSeeAdmin`` so only platform admins ever saw Storage Types in the sidebar. But the backend route (``gpu_instance_persistent_volume_types``) is tenant-scoped — Org owners can create / list their own — so hiding the menu from them left an admin-defined feature reachable only by URL.

Relax to ``canSeeOrgAdmin`` to match. OSS keeps the platform-admin-only behaviour (predicate defaults to ``isPlatformAdmin``); the enterprise access extension widens it to the current-org owner.