### PR TITLE
fix: improve model name tooltip text contrast

### DIFF
--- a/src/global.less
+++ b/src/global.less
@@ -715,6 +715,7 @@ body {
   .ant-tooltip-content {
     .ant-tooltip-inner {
       max-width: var(--width-tooltip-max);
+      color: var(--color-white-primary);
 
       .text-tertiary {
         color: var(--color-white-secondary);

--- a/src/pages/llmodels/hooks/use-models-columns.tsx
+++ b/src/pages/llmodels/hooks/use-models-columns.tsx
@@ -161,11 +161,7 @@ const useModelsColumns = ({
           <Flex align="center" gap={4} style={{ maxWidth: '100%' }}>
             <AutoTooltip
               ghost
-              title={
-                <span style={{ color: 'var(--ant-color-text-light-solid)' }}>
-                  {text}
-                </span>
-              }
+              title={text}
             >
               <span className="text-primary font-400">{text}</span>
             </AutoTooltip>


### PR DESCRIPTION
## Description

Fix the model name hover tooltip text color to have proper contrast against the tooltip background.

### Issue
The tooltip text used `var(--ant-color-text-light-solid)` as its color, which could resolve incorrectly and cause the text to be the same color as the tooltip background, making it illegible.

### Changes
1. **src/global.less**: Added `color: var(--color-white-primary)` to `.ant-tooltip-inner` to ensure tooltip text always renders as white on the dark tooltip background.
2. **src/pages/llmodels/hooks/use-models-columns.tsx**: Removed the explicit and potentially problematic `color: var(--ant-color-text-light-solid)` inline style from the model name tooltip title span. The tooltip now inherits its text color from the parent tooltip container, which is set via the global styles.

Refs gpustack/gpustack#5353