### PR TITLE
fix: resolve deploy model form requiring double save click

### DIFF
--- a/src/pages/llmodels/config/form-context.ts
+++ b/src/pages/llmodels/config/form-context.ts
@@ -30,6 +30,7 @@ interface FormContextProps {
   flatBackendOptions: BackendOption[];
   initialValues?: FormData; // for editing model
   modelContextData?: Record<string, any>;
+  submitAttempted?: boolean;
   clearCacheFormValues?: () => void;
   onValuesChange?: (changedValues: any, allValues: any) => void;
   onBackendChange: (backend: string, option: any) => void;

--- a/src/pages/llmodels/forms/index.tsx
+++ b/src/pages/llmodels/forms/index.tsx
@@ -101,6 +101,7 @@ const DataForm: React.FC<DataFormProps> = forwardRef((props, ref) => {
   const [form] = Form.useForm();
   const intl = useIntl();
   const [activeKey, setActiveKey] = React.useState<string[]>([]);
+  const [submitAttempted, setSubmitAttempted] = React.useState(false);
   const { modelContextData, fetchContextLength } = useQueryContextLength();
   const localPath = Form.useWatch('local_path', form);
   const modelScopeModelId = Form.useWatch('model_scope_model_id', form);
@@ -282,6 +283,7 @@ const DataForm: React.FC<DataFormProps> = forwardRef((props, ref) => {
   };
 
   const handleOnFinishFailed = (errorInfo: any) => {
+    setSubmitAttempted(true);
     const { errorFields } = errorInfo;
     if (errorFields && errorFields.length > 0) {
       const collapseKeys: string[] = [];
@@ -398,6 +400,7 @@ const DataForm: React.FC<DataFormProps> = forwardRef((props, ref) => {
         workerLabelOptions: workerLabelOptions,
         initialValues: initialValues,
         modelContextData: modelContextData,
+        submitAttempted: submitAttempted,
         clearCacheFormValues: clearCacheFormValues,
         onValuesChange: onValuesChange,
         onBackendChange: handleBackendChange

--- a/src/pages/llmodels/forms/model-lora-list.tsx
+++ b/src/pages/llmodels/forms/model-lora-list.tsx
@@ -3,6 +3,7 @@ import { useIntl } from '@umijs/max';
 import { Form } from 'antd';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { FormData, LoraListItem } from '../config/types';
+import { useFormContext } from '../config/form-context';
 import useQueryModelLoraList from '../services/use-query-lora-list';
 import LoraItem from './lora-list-item';
 
@@ -20,9 +21,10 @@ const ModelLoraList = () => {
   console.log('fetching lora list with base', base, form.getFieldsValue());
 
   const { dataList: defaultDataList, fetchData } = useQueryModelLoraList();
+  const { submitAttempted } = useFormContext();
+  const validated = !!submitAttempted;
 
   const [itemList, setItemList] = useState<ItemValue[]>([]);
-  const [validated, setValidated] = useState(false);
   const initializedRef = useRef(false);
   const prevBaseRef = useRef<string>('');
 
@@ -150,9 +152,6 @@ const ModelLoraList = () => {
       rules={[
         {
           validator: async (_, value: LoraListItem[]) => {
-            if (!validated) {
-              setValidated(true);
-            }
             if (!value || value.length === 0) return;
 
             for (const it of value) {


### PR DESCRIPTION
## Description

Fixes a UI bug where deploying a model from the catalog requires clicking Save twice. The first click does nothing while the second click succeeds.

## Root Cause

The LoRA list field in the deploy form had a custom async validator that called `setValidated(true)` inside the validation function. This triggered a React state update during antd's form submission pipeline, which caused the first form submit to be silently dropped.

## Fix

- Replaced the local `useState`-based `validated` flag with a context-based `submitAttempted` flag
- `submitAttempted` is set by the form's `onFinishFailed` handler instead of inside the async validator
- The LoRA list validator no longer calls `setState`, preventing React re-renders from interrupting form submission

Closes #5425