### PR TITLE
feat(api-keys): rename User Name column to Creator and move before Created

### DIFF
--- a/src/locales/en-US/common.ts
+++ b/src/locales/en-US/common.ts
@@ -55,6 +55,7 @@ export default {
   'common.button.viewevent': 'View Events',
   'common.button.recreate': 'Recreate',
   'common.table.operation': 'Operations',
+  'common.table.creator': 'Creator',
   'common.table.createTime': 'Created',
   'common.table.updateTime': 'Updated',
   'common.table.description': 'Description',

--- a/src/locales/ja-JP/common.ts
+++ b/src/locales/ja-JP/common.ts
@@ -55,6 +55,7 @@ export default {
   'common.button.viewevent': 'イベントを表示',
   'common.button.recreate': '再作成',
   'common.table.operation': '操作',
+  'common.table.creator': '作成者',
   'common.table.createTime': '作成日時',
   'common.table.updateTime': '更新日時',
   'common.table.description': '説明',

--- a/src/locales/ru-RU/common.ts
+++ b/src/locales/ru-RU/common.ts
@@ -55,6 +55,7 @@ export default {
   'common.button.viewevent': 'Просмотр событий',
   'common.button.recreate': 'Пересоздать',
   'common.table.operation': 'Действия',
+  'common.table.creator': 'Создатель',
   'common.table.createTime': 'Создано',
   'common.table.updateTime': 'Обновлено',
   'common.table.description': 'Описание',

--- a/src/locales/tr-TR/common.ts
+++ b/src/locales/tr-TR/common.ts
@@ -55,6 +55,7 @@ export default {
   'common.button.viewevent': 'Olayları Görüntüle',
   'common.button.recreate': 'Yeniden Oluştur',
   'common.table.operation': 'İşlemler',
+  'common.table.creator': 'Oluşturan',
   'common.table.createTime': 'Oluşturulma',
   'common.table.updateTime': 'Güncellenme',
   'common.table.description': 'Açıklama',

--- a/src/locales/zh-CN/common.ts
+++ b/src/locales/zh-CN/common.ts
@@ -52,6 +52,7 @@ export default {
   'common.button.viewlog': '查看日志',
   'common.button.viewevent': '查看事件',
   'common.table.operation': '操作',
+  'common.table.creator': '创建者',
   'common.table.createTime': '创建时间',
   'common.table.updateTime': '更新时间',
   'common.table.description': '描述',

--- a/src/pages/api-keys/hooks/use-keys-columns.tsx
+++ b/src/pages/api-keys/hooks/use-keys-columns.tsx
@@ -110,17 +110,6 @@ const useModelsColumns = ({
         )
       },
       {
-        title: intl.formatMessage({ id: 'users.table.username' }),
-        dataIndex: 'user_name',
-        key: 'user_name',
-        hidden: !is_admin,
-        render: (text: string, record: ListItem) => (
-          <AutoTooltip ghost style={{ maxWidth: 200 }}>
-            {text || '-'}
-          </AutoTooltip>
-        )
-      },
-      {
         title: intl.formatMessage({ id: 'apikeys.form.expiretime' }),
         dataIndex: 'expires_at',
         key: 'expires_at',
@@ -185,6 +174,17 @@ const useModelsColumns = ({
         },
         render: (text: string, record: ListItem) => (
           <AutoTooltip ghost>{text}</AutoTooltip>
+        )
+      },
+      {
+        title: intl.formatMessage({ id: 'common.table.creator' }),
+        dataIndex: 'user_name',
+        key: 'user_name',
+        hidden: !is_admin,
+        render: (text: string) => (
+          <AutoTooltip ghost style={{ maxWidth: 200 }}>
+            {text || '-'}
+          </AutoTooltip>
         )
       },
       {


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5083

Rename the api-keys list column from User Name to Creator for clarity and reorder it to sit immediately before the Created column. Add the common.table.creator locale key across all supported languages.