### PR TITLE
feat(login): add plugin seam for default landing path

### DIFF
--- a/src/pages/login/utils.ts
+++ b/src/pages/login/utils.ts
@@ -1,29 +1,48 @@
 import { DEFAULT_ENTER_PAGE } from '@/config/settings';
+import { getGPUStackPlugin } from '@/plugins';
 import { isOnline } from '@/utils';
 import {
   IS_FIRST_LOGIN,
   readState,
   writeState
 } from '@/utils/localstore/index';
-import { history } from '@umijs/max';
+import { history, request } from '@umijs/max';
+
+const resolvePluginPath = async (
+  userInfo: any
+): Promise<string | null | undefined> => {
+  try {
+    return await getGPUStackPlugin()?.login?.resolveDefaultPath?.(userInfo, {
+      request
+    });
+  } catch {
+    return null;
+  }
+};
 
 export const checkDefaultPage = async (userInfo: any, replace: boolean) => {
-  const isFirstLogin = await readState(IS_FIRST_LOGIN);
+  const [isFirstLogin, overridePath] = await Promise.all([
+    readState(IS_FIRST_LOGIN),
+    resolvePluginPath(userInfo)
+  ]);
 
   if (isFirstLogin === null && isOnline()) {
     writeState(IS_FIRST_LOGIN, true);
     const pathname =
-      userInfo && userInfo?.is_admin
+      overridePath ||
+      (userInfo && userInfo?.is_admin
         ? DEFAULT_ENTER_PAGE.adminForFirst
-        : DEFAULT_ENTER_PAGE.user;
+        : DEFAULT_ENTER_PAGE.user);
     history.push(pathname);
     return;
   }
   await writeState(IS_FIRST_LOGIN, false);
 
-  const pathname = userInfo?.is_admin
-    ? DEFAULT_ENTER_PAGE.adminForNormal
-    : DEFAULT_ENTER_PAGE.user;
+  const pathname =
+    overridePath ||
+    (userInfo?.is_admin
+      ? DEFAULT_ENTER_PAGE.adminForNormal
+      : DEFAULT_ENTER_PAGE.user);
 
   history.push(pathname, { replace: replace });
 };

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -48,6 +48,15 @@ export interface LoginKit {
 export interface LoginPlugin {
   shouldUseCustomLogin?: (enterpriseSettings: any) => boolean;
   CustomLoginComponent?: ComponentType<{ kit: LoginKit }>;
+  /**
+   * Seam for plugins to override the default landing path after login.
+   * Returning a path overrides both the admin and non-admin defaults;
+   * returning null/undefined falls back to the built-in behavior.
+   */
+  resolveDefaultPath?: (
+    userInfo: any,
+    ctx: { request: <T = any>(url: string, options?: any) => Promise<T> }
+  ) => Promise<string | null | undefined> | string | null | undefined;
 }
 
 /**


### PR DESCRIPTION
Plugins can supply `LoginPlugin.resolveDefaultPath` to override the post-login redirect target. checkDefaultPage consults the hook and uses the returned path when non-null; otherwise falls back to the existing admin/non-admin defaults. Applies to both first-login and subsequent-login flows.