### PR TITLE
feat(version): respect VERSION env override in build info

### DIFF
--- a/config/utils.ts
+++ b/config/utils.ts
@@ -1,13 +1,27 @@
-const child_process = require('child_process');
+import { execSync } from 'child_process';
 
 export const getBranchInfo = () => {
-  const latestCommit = child_process
-    .execSync('git rev-parse HEAD')
-    .toString()
-    .trim();
-  const versionTag = child_process
-    .execSync(`git tag --contains ${latestCommit}`)
-    .toString()
-    .trim();
-  return { version: versionTag || '', commitId: latestCommit.slice(0, 7) };
+  // git may be absent (source archive, bare container) or this tree may
+  // not be a git checkout. Swallow the failure and fall back to the env
+  // overrides below — losing build info shouldn't fail the build.
+  let latestCommit = '';
+  let versionTag = '';
+  try {
+    latestCommit = execSync('git rev-parse HEAD').toString().trim();
+    versionTag = execSync(`git tag --contains ${latestCommit}`)
+      .toString()
+      .trim();
+  } catch {
+    // Not a git checkout / git unavailable; rely on env overrides.
+  }
+  // Respect explicit GPUSTACK_UI_* overrides so a wrapping build that
+  // checks this source tree out as a sub-package can stamp its own
+  // release tag and commit id onto the UI (otherwise the panel reports
+  // the host tree's git HEAD, which the wrapper doesn't control).
+  const overrideVersion = process.env.GPUSTACK_UI_VERSION?.trim();
+  const overrideCommitId = process.env.GPUSTACK_UI_COMMIT_ID?.trim();
+  return {
+    version: overrideVersion || versionTag || '',
+    commitId: overrideCommitId || latestCommit.slice(0, 7)
+  };
 };


### PR DESCRIPTION
Allows a wrapping build to stamp its own release tag into the UI when the source tree's git HEAD does not carry the desired tag. Falls back to the git tag (then commit id) when unset, preserving existing behavior.