### PR TITLE
fix(api-keys): scope creator filter to current org members

### DIFF
--- a/src/pages/api-keys/index.tsx
+++ b/src/pages/api-keys/index.tsx
@@ -97,8 +97,15 @@ const APIKeys: React.FC = () => {
   });
 
   useEffect(() => {
+    // `scope=current_org` limits the creator dropdown to members of the
+    // active Org. Without it, an Org owner sees every user in the
+    // system — most of whom can't own a key visible in this list, so
+    // selecting them produces an empty result. The BE drops the
+    // param silently when the request has no Org context, so callers
+    // without an Org keep the full-directory behavior.
     fetchUserData({
-      page: -1
+      page: -1,
+      scope: 'current_org'
     });
     return () => {
       cancelUserRequest();


### PR DESCRIPTION
The "Filter by creator" dropdown was listing every user in the system. For an Org owner viewing an Org-scoped key list, picking a user outside the Org always produced an empty result. Pass scope=current_org to `/user-directory` so the picker matches the list's actual scope. BE drops the param when the request has no Org context, so callers without an Org are unchanged.