### PR TITLE
fix: playground model name prefix for non-platform org

### DIFF
--- a/src/pages/llmodels/components/model-item.tsx
+++ b/src/pages/llmodels/components/model-item.tsx
@@ -119,13 +119,16 @@ const renderTag = (item: any, index = 0) => {
 
 const ModelItem: React.FC<{
   model: Record<string, any>;
-  onClick: (model: any) => void;
 }> = (props) => {
-  const { model, onClick } = props;
+  const { model } = props;
   const intl = useIntl();
   const navigate = useNavigate();
 
-  const handleOpenPlayGround = () => {
+  // ``model.name`` from ``/v2/my-models`` is the OpenAI-style id
+  // (org-prefixed for non-platform routes, bare for platform). Use it
+  // verbatim — the playground / dispatcher both key off that exact id.
+  const handleOpenPlayGroundClick = () => {
+    const modelName = encodeURIComponent(model.name);
     for (const [category, path] of Object.entries(categoryToPathMap)) {
       if (
         model.categories?.includes(category) &&
@@ -134,15 +137,15 @@ const ModelItem: React.FC<{
           modelCategoriesMap.speech_to_text
         ].includes(category)
       ) {
-        navigate(`${path}&model=${model.name}`);
+        navigate(`${path}&model=${modelName}`);
         return;
       }
       if (model.categories?.includes(category)) {
-        navigate(`${path}?model=${model.name}`);
+        navigate(`${path}?model=${modelName}`);
         return;
       }
     }
-    navigate(`/playground/chat?model=${model.name}`);
+    navigate(`/playground/chat?model=${modelName}`);
   };
 
   // context length
@@ -167,7 +170,6 @@ const ModelItem: React.FC<{
     <CardWrapper>
       <TemplateCard
         height={140}
-        onClick={() => onClick(model)}
         clickable={false}
         hoverable={true}
         ghost
@@ -237,7 +239,7 @@ const ModelItem: React.FC<{
                   size="middle"
                   className="btn"
                   type="primary"
-                  onClick={handleOpenPlayGround}
+                  onClick={handleOpenPlayGroundClick}
                 >
                   {intl.formatMessage({ id: 'models.openinplayground' })}
                 </Button>

--- a/src/pages/llmodels/user-models.tsx
+++ b/src/pages/llmodels/user-models.tsx
@@ -8,19 +8,14 @@ import {
   PageTools,
   TemplateCardList
 } from '@gpustack/core-ui';
-import { useIntl, useNavigate } from '@umijs/max';
+import { useIntl } from '@umijs/max';
 import useMemoizedFn from 'ahooks/lib/useMemoizedFn';
 import { Button, Input, Space } from 'antd';
 import React, { useCallback, useMemo } from 'react';
 import PageBox from '../_components/page-box';
 import { MY_MODELS_API, queryMyModels } from './apis';
 import ModelItem from './components/model-item';
-import {
-  categoryOptions,
-  modelCategoriesMap,
-  MyModelsStatusValueMap
-} from './config';
-import { categoryToPathMap } from './config/button-actions';
+import { categoryOptions, MyModelsStatusValueMap } from './config';
 const Dot = ({ color }: { color: string }) => {
   return (
     <span
@@ -45,7 +40,6 @@ const optionRender = (item: any) => {
 };
 
 const UserModels: React.FC = () => {
-  const navigate = useNavigate();
   const {
     dataSource,
     queryParams,
@@ -96,28 +90,8 @@ const UserModels: React.FC = () => {
     });
   };
 
-  const handleOnClick = (model: any) => {
-    for (const [category, path] of Object.entries(categoryToPathMap)) {
-      if (
-        model.categories?.includes(category) &&
-        [
-          modelCategoriesMap.text_to_speech,
-          modelCategoriesMap.speech_to_text
-        ].includes(category)
-      ) {
-        navigate(`${path}&model=${model.name}`);
-        return;
-      }
-      if (model.categories?.includes(category)) {
-        navigate(`${path}?model=${model.name}`);
-        return;
-      }
-    }
-    navigate(`/playground/chat?model=${model.name}`);
-  };
-
   const renderCard = (data: any) => {
-    return <ModelItem model={data} onClick={handleOnClick} />;
+    return <ModelItem model={data} />;
   };
 
   const loadMore = useMemoizedFn((nextPage: number) => {

--- a/src/pages/model-routes/hooks/use-open-playground.ts
+++ b/src/pages/model-routes/hooks/use-open-playground.ts
@@ -8,8 +8,15 @@ const useOpenPlayground = () => {
 
   const generateModelName = (row: any) => {
     const org = getOrgById(row.owner_principal_id) ?? getCurrentOrg();
+    // The platform Org is always named ``default`` (backend constant
+    // ``PLATFORM_PRINCIPAL_NAME``); its models are reported by
+    // ``/v1/models`` without a prefix. Match by name too, not just the
+    // ``is_platform`` flag — pre-multi-tenancy OSS caches and any other
+    // path that drops the flag would otherwise emit ``default/<name>``
+    // and 404 against the unprefixed model id.
+    const isPlatformOrg = org?.is_platform || org?.name === 'default';
     const rawModel =
-      org?.name && !org.is_platform ? `${org.name}/${row.name}` : row.name;
+      org?.name && !isPlatformOrg ? `${org.name}/${row.name}` : row.name;
     return rawModel;
   };
 


### PR DESCRIPTION
Treat the platform org by either ``is_platform`` flag or the well-known ``default`` name — stale / unpopulated caches dropped the flag and the Open-in-Playground URL ended up as ``default/<name>``, which 404s against ``/v1/models``' unprefixed id.
