### PR TITLE
feat: add GitHub star button to top bar

### DIFF
--- a/src/layouts/extraRender.tsx
+++ b/src/layouts/extraRender.tsx
@@ -18,6 +18,7 @@ import { useAtom } from 'jotai';
 import { useMemo } from 'react';
 import styled from 'styled-components';
 import { DEFAULT_ENTER_PAGE } from '../config/settings';
+import GithubStar from './github-star';
 
 const NewLabel = styled.span`
   position: relative;
@@ -260,6 +261,7 @@ export const ExtraContent = (props: { isDarkTheme?: boolean }) => {
     <Wrapper>
       {contextHolder}
       <PluginExtraField name="OrgSwitcher" isDarkTheme={isDarkTheme} />
+      {process.env.ENABLE_ENTERPRISE !== 'true' && <GithubStar />}
       <div
         style={{
           display: 'flex',

--- a/src/layouts/github-star.tsx
+++ b/src/layouts/github-star.tsx
@@ -1,0 +1,140 @@
+import externalLinks from '@/constants/external-links';
+import { GithubFilled } from '@ant-design/icons';
+import { useIntl } from '@umijs/max';
+import { Tooltip } from 'antd';
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+const REPO = 'gpustack/gpustack';
+const CACHE_KEY = 'gpustack:github-stars';
+const CACHE_TTL = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT = 4000;
+
+const StarLink = styled.a`
+  display: inline-flex;
+  align-items: stretch;
+  height: 24px;
+  border-radius: var(--ant-border-radius);
+  border: 1px solid var(--ant-color-border-secondary);
+  background-color: var(--ant-color-bg-container);
+  color: var(--ant-color-text-secondary);
+  font-size: 12px;
+  line-height: 1;
+  overflow: hidden;
+  transition:
+    border-color 0.2s,
+    color 0.2s;
+
+  &:hover {
+    border-color: var(--ant-color-border);
+    color: var(--ant-color-text);
+  }
+
+  .seg {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0 8px;
+  }
+
+  .seg + .seg {
+    border-left: 1px solid var(--ant-color-border-secondary);
+    background-color: var(--ant-color-fill-quaternary);
+  }
+
+  .anticon {
+    font-size: 13px;
+  }
+
+  .count {
+    font-weight: 500;
+    font-variant-numeric: tabular-nums;
+    min-width: 1.5em;
+    text-align: center;
+  }
+`;
+
+const formatCount = (n: number): string => {
+  if (n >= 1000) {
+    const k = n / 1000;
+    return k >= 10 ? `${Math.round(k)}k` : `${k.toFixed(1)}k`;
+  }
+  return String(n);
+};
+
+type CacheEntry = { value: number; time: number };
+
+const readCache = (): CacheEntry | null => {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.value !== 'number' || typeof parsed?.time !== 'number') {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+};
+
+const writeCache = (value: number) => {
+  try {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ value, time: Date.now() })
+    );
+  } catch {
+    // ignore quota errors
+  }
+};
+
+const GithubStar = () => {
+  const intl = useIntl();
+  const [count, setCount] = useState<number | null>(
+    () => readCache()?.value ?? null
+  );
+
+  useEffect(() => {
+    const cached = readCache();
+    const fresh = cached && Date.now() - cached.time < CACHE_TTL;
+    if (fresh) return;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+
+    fetch(`https://api.github.com/repos/${REPO}`, { signal: controller.signal })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!data || typeof data.stargazers_count !== 'number') return;
+        setCount(data.stargazers_count);
+        writeCache(data.stargazers_count);
+      })
+      .catch(() => {
+        // offline, blocked, rate-limited — stay hidden if no cache
+      })
+      .finally(() => clearTimeout(timer));
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, []);
+
+  return (
+    <Tooltip title={intl.formatMessage({ id: 'common.github.star.tooltip' })}>
+      <StarLink href={externalLinks.github} target="_blank" rel="noreferrer">
+        <span className="seg">
+          <GithubFilled />
+        </span>
+        <span className="seg">
+          <span className="count">
+            {count != null ? formatCount(count) : 'Star'}
+          </span>
+        </span>
+      </StarLink>
+    </Tooltip>
+  );
+};
+
+export default GithubStar;

--- a/src/locales/en-US/common.ts
+++ b/src/locales/en-US/common.ts
@@ -169,6 +169,7 @@ export default {
   'common.time.hour': 'hour',
   'common.time.minute': 'minutes',
   'common.issue.report': 'Report an issue',
+  'common.github.star.tooltip': 'Star us on GitHub',
   'common.social.discord': 'Join Our Discord',
   'common.table.mark': 'Comment',
   'common.table.rollback.mark': 'Rollback Comment',

--- a/src/locales/ja-JP/common.ts
+++ b/src/locales/ja-JP/common.ts
@@ -170,6 +170,7 @@ export default {
   'common.time.hour': '時間',
   'common.time.minute': '分',
   'common.issue.report': '問題を報告',
+  'common.github.star.tooltip': 'GitHub でスターをつける',
   'common.social.discord': 'Discordに参加',
   'common.table.mark': 'コメント',
   'common.table.rollback.mark': 'ロールバックコメント',

--- a/src/locales/ru-RU/common.ts
+++ b/src/locales/ru-RU/common.ts
@@ -167,6 +167,7 @@ export default {
   'common.time.hour': 'Час',
   'common.time.minute': 'Минута',
   'common.issue.report': 'Сообщить о проблеме',
+  'common.github.star.tooltip': 'Поставьте нам звезду на GitHub',
   'common.social.discord': 'Присоединиться к Discord',
   'common.table.mark': 'Комментарий',
   'common.table.rollback.mark': 'Комментарий к откату',

--- a/src/locales/tr-TR/common.ts
+++ b/src/locales/tr-TR/common.ts
@@ -167,6 +167,7 @@ export default {
   'common.time.hour': 'saat',
   'common.time.minute': 'dakika',
   'common.issue.report': 'Sorun bildir',
+  'common.github.star.tooltip': "GitHub'da bize yıldız verin",
   'common.social.discord': "Discord'umuza Katılın",
   'common.table.mark': 'Yorum',
   'common.table.rollback.mark': 'Geri Alma Yorumu',

--- a/src/locales/zh-CN/common.ts
+++ b/src/locales/zh-CN/common.ts
@@ -161,6 +161,7 @@ export default {
   'common.time.hour': '小时',
   'common.time.minute': '分钟',
   'common.issue.report': '问题反馈',
+  'common.github.star.tooltip': '在 GitHub 上 Star 我们',
   'common.social.discord': '加入我们的Discord',
   'common.table.mark': '备注',
   'common.table.rollback.mark': '回滚备注',


### PR DESCRIPTION
Compact pill (GitHub icon | star count) placed left of the version display. Star count is fetched from the GitHub API once per 24h and cached in localStorage; the button hides entirely when no count is available (e.g. air-gapped deployments), matching the existing update- check graceful-degradation pattern. Fetch is bounded by a 4s abort timeout to avoid hanging requests offline.