### PR TITLE
feat(apikeys): wire Organization plugin column on API Keys list

### DIFF
--- a/src/pages/api-keys/config/types.ts
+++ b/src/pages/api-keys/config/types.ts
@@ -3,6 +3,13 @@ export interface ListItem {
   description: string;
   id: number;
   value: string;
+  masked_value?: string;
+  user_id?: number;
+  user_name?: string;
+  // The owning principal — an Org, or a USER principal when the key
+  // was created in someone's Personal Org. Read by the enterprise
+  // plugin's Organization column in the admin All-org view.
+  owner_principal_id?: number;
   created_at: string;
   updated_at: string;
   expires_at: string;

--- a/src/pages/api-keys/hooks/use-keys-columns.tsx
+++ b/src/pages/api-keys/hooks/use-keys-columns.tsx
@@ -1,5 +1,6 @@
 // columns.ts
 import { tableSorter } from '@/config/settings';
+import { usePluginListColumns } from '@/plugins/list-extra-columns';
 import { DashboardOutlined } from '@ant-design/icons';
 import {
   AutoTooltip,
@@ -48,6 +49,7 @@ const useModelsColumns = ({
   onConfigAction
 }: ColumnsHookProps): ColumnsType<ListItem> => {
   const intl = useIntl();
+  const pluginCols = usePluginListColumns('apiKeys');
 
   const actionList = useMemo<APIKeyAction[]>(() => {
     // Built-ins use a step-of-10 priority scale so plugins have room
@@ -124,6 +126,12 @@ const useModelsColumns = ({
   }, [intl, configActions, onConfigAction]);
 
   return useMemo(() => {
+    const pluginRendered = pluginCols.map((c) => ({
+      title: intl.formatMessage({ id: c.titleId }),
+      key: c.key,
+      ellipsis: { showTitle: false },
+      render: (_text: any, record: ListItem) => c.render(record)
+    }));
     return [
       {
         title: intl.formatMessage({ id: 'common.table.name' }),
@@ -152,6 +160,7 @@ const useModelsColumns = ({
           </span>
         )
       },
+      ...pluginRendered,
       {
         title: intl.formatMessage({ id: 'apikeys.table.key' }),
         dataIndex: 'masked_value',
@@ -269,7 +278,7 @@ const useModelsColumns = ({
         )
       }
     ];
-  }, [intl, showCreator, handleSelect, actionList]);
+  }, [intl, showCreator, handleSelect, actionList, pluginCols]);
 };
 
 export default useModelsColumns;


### PR DESCRIPTION
Splice the per-page extra-columns slot ('apiKeys') after the Name column so plugin-contributed columns (e.g. Organization in the admin All-org view) render on the API Keys list, matching the other resource list pages. Declare owner_principal_id (and the already-consumed masked_value / user_name / user_id) on ListItem.