### PR TITLE
chore: bump @gpustack/core-ui to v1.0.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@ant-design/pro-components": "3.1.0-0",
     "@antv/g6": "^5.0.51",
     "@braintree/sanitize-url": "^7.1.1",
-    "@gpustack/core-ui": "^1.0.33",
+    "@gpustack/core-ui": "^1.0.34",
     "@huggingface/gguf": "^0.1.7",
     "@huggingface/hub": "^0.15.1",
     "@huggingface/tasks": "^0.11.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.2
       '@gpustack/core-ui':
-        specifier: ^1.0.33
-        version: 1.0.33(czdvzceysqw7iv6pct2ucnb23e)
+        specifier: ^1.0.34
+        version: 1.0.34(czdvzceysqw7iv6pct2ucnb23e)
       '@huggingface/gguf':
         specifier: ^0.1.7
         version: 0.1.18
@@ -1484,8 +1484,8 @@ packages:
     resolution: {integrity: sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ==, tarball: https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz}
     deprecated: the package is rather renamed to @formatjs/ecma-abstract with some changes in functionality (primarily selectUnit is removed and we don't plan to make any further changes to this package
 
-  '@gpustack/core-ui@1.0.33':
-    resolution: {integrity: sha512-oCJ+wnsZ9Cxvx5lzpr3ebmPlzwaSTGbbetrK8z9cGvygP5VkuRpoZk4n9Ic7BAARoGk0Bxbb4ZSEhaLgVEb8lQ==, tarball: https://registry.npmjs.org/@gpustack/core-ui/-/core-ui-1.0.33.tgz}
+  '@gpustack/core-ui@1.0.34':
+    resolution: {integrity: sha512-jLmMX6VnAWDErQAyx73sfEi5fvuvYklC9BLM+7u+ErARX6VQrbK2gIDp5m/jrNaUysxIuOrQAlxhLSBUlOxWdA==, tarball: https://registry.npmjs.org/@gpustack/core-ui/-/core-ui-1.0.34.tgz}
     peerDependencies:
       '@ant-design/icons': ^6.1.0
       '@ant-design/pro-components': 3.1.0-0
@@ -10808,7 +10808,7 @@ snapshots:
 
   '@formatjs/intl-utils@2.3.0': {}
 
-  '@gpustack/core-ui@1.0.33(czdvzceysqw7iv6pct2ucnb23e)':
+  '@gpustack/core-ui@1.0.34(czdvzceysqw7iv6pct2ucnb23e)':
     dependencies:
       '@ant-design/icons': 6.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@ant-design/pro-components': 3.1.0-0(antd@6.3.7(date-fns@2.30.0)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
Automated bump from [@gpustack/core-ui v1.0.34](https://github.com/gpustack/core-ui/releases/tag/v1.0.34).