### PR TITLE
feat(models): vgpu schedule mode for model deployment

### DIFF
--- a/src/atoms/models.ts
+++ b/src/atoms/models.ts
@@ -28,6 +28,7 @@ export const clusterListAtom = atom<
     provider: string;
     state: string;
     is_default: boolean;
+    gpu_instance_enabled?: boolean;
     workers: number;
     ready_workers: number;
     gpus: number;

--- a/src/locales/en-US/models.ts
+++ b/src/locales/en-US/models.ts
@@ -53,8 +53,17 @@ export default {
     'Automatically deploys model instances to appropriate GPUs based on current resource conditions.',
   'models.form.scheduletype.manual.tips':
     'Allows you to manually specify the GPUs to deploy the model instances to.',
+  'models.form.gpuallocation': 'GPU Allocation',
+  'models.form.gpumode.full': 'Full',
+  'models.form.gpumode.slicing': 'Slicing',
+  'models.form.gpuType.noSlicedCapacity':
+    'No sliceable capacity available on this GPU type, please choose another GPU type.',
+  'models.form.gpuType.noPartitionProfile':
+    'No partition profile available on this GPU type, please choose another GPU type.',
   'models.form.manual.schedule': 'Manual Schedule',
   'models.table.gpuindex': 'GPU Index',
+  'models.table.vgpu': 'vGPU',
+  'models.table.vgpu.slice': '{memory}% VRAM / {cores}% Compute',
   'models.table.backend': 'Backends',
   'models.table.acrossworker': 'Distributed Across Workers',
   'models.table.cpuoffload': 'CPU Offload',

--- a/src/locales/ja-JP/models.ts
+++ b/src/locales/ja-JP/models.ts
@@ -54,8 +54,17 @@ export default {
     '現在のリソース状況に基づいて、モデルインスタンスを適切なGPUに自動的にデプロイします。',
   'models.form.scheduletype.manual.tips':
     'モデルインスタンスをデプロイするGPUを手動で指定できます。',
+  'models.form.gpuallocation': 'GPU 割り当て',
+  'models.form.gpumode.full': '全体',
+  'models.form.gpumode.slicing': '分割',
+  'models.form.gpuType.noSlicedCapacity':
+    'この GPU タイプに分割可能な容量がありません。別の GPU タイプを選択してください。',
+  'models.form.gpuType.noPartitionProfile':
+    'この GPU タイプに利用可能な分割プロファイルがありません。別の GPU タイプを選択してください。',
   'models.form.manual.schedule': '手動スケジュール',
   'models.table.gpuindex': 'GPUインデックス',
+  'models.table.vgpu': 'vGPU',
+  'models.table.vgpu.slice': '{memory}% VRAM / {cores}% 演算',
   'models.table.backend': 'バックエンド',
   'models.table.acrossworker': 'ワーカー間で分散',
   'models.table.cpuoffload': 'CPUオフロード',

--- a/src/locales/ru-RU/models.ts
+++ b/src/locales/ru-RU/models.ts
@@ -55,8 +55,17 @@ export default {
     'Автоматическое развертывание инстансов модели на подходящие GPU в зависимости от текущих ресурсов.',
   'models.form.scheduletype.manual.tips':
     'Позволяет вручную указать GPU для развертывания инстансов модели.',
+  'models.form.gpuallocation': 'Распределение GPU',
+  'models.form.gpumode.full': 'Целиком',
+  'models.form.gpumode.slicing': 'Нарезка',
+  'models.form.gpuType.noSlicedCapacity':
+    'Нет доступной ёмкости для нарезки у этого типа GPU, выберите другой тип GPU.',
+  'models.form.gpuType.noPartitionProfile':
+    'Нет доступного профиля раздела у этого типа GPU, выберите другой тип GPU.',
   'models.form.manual.schedule': 'Ручное распределение',
   'models.table.gpuindex': 'Индекс GPU',
+  'models.table.vgpu': 'vGPU',
+  'models.table.vgpu.slice': '{memory}% VRAM / {cores}% вычислений',
   'models.table.backend': 'Бэкенды',
   'models.table.acrossworker': 'Распределение по воркерам',
   'models.table.cpuoffload': 'CPU оффлоуд',

--- a/src/locales/tr-TR/models.ts
+++ b/src/locales/tr-TR/models.ts
@@ -53,8 +53,17 @@ export default {
     "Mevcut kaynak koşullarına göre model örneklerini uygun GPU'lara otomatik olarak dağıtır.",
   'models.form.scheduletype.manual.tips':
     "Model örneklerinin dağıtılacağı GPU'ları manuel olarak belirlemenize olanak tanır.",
+  'models.form.gpuallocation': 'GPU Tahsisi',
+  'models.form.gpumode.full': 'Tam',
+  'models.form.gpumode.slicing': 'Dilimleme',
+  'models.form.gpuType.noSlicedCapacity':
+    'Bu GPU türünde dilimlenebilir kapasite yok, lütfen başka bir GPU türü seçin.',
+  'models.form.gpuType.noPartitionProfile':
+    'Bu GPU türünde kullanılabilir bölüm profili yok, lütfen başka bir GPU türü seçin.',
   'models.form.manual.schedule': 'Manuel Zamanlama',
   'models.table.gpuindex': 'GPU İndeksi',
+  'models.table.vgpu': 'vGPU',
+  'models.table.vgpu.slice': '{memory}% VRAM / {cores}% İşlem',
   'models.table.backend': 'Altyapılar',
   'models.table.acrossworker': 'İşçi Düğümler Arası Dağıtık',
   'models.table.cpuoffload': 'CPU Aktarımı',

--- a/src/locales/zh-CN/models.ts
+++ b/src/locales/zh-CN/models.ts
@@ -53,8 +53,17 @@ export default {
   'models.form.scheduletype.auto.tips':
     '自动根据当前资源情况部署模型实例到合适的 GPU 上。',
   'models.form.scheduletype.manual.tips': '可指定模型实例部署的 GPU。',
+  'models.form.gpuallocation': 'GPU 分配',
+  'models.form.gpumode.full': '整卡',
+  'models.form.gpumode.slicing': '切分',
+  'models.form.gpuType.noSlicedCapacity':
+    '该 GPU 类型没有可切分的容量，请选择其他 GPU 类型。',
+  'models.form.gpuType.noPartitionProfile':
+    '该 GPU 类型没有可用的切分规格，请选择其他 GPU 类型。',
   'models.form.manual.schedule': '手动调度',
   'models.table.gpuindex': 'GPU 序号',
+  'models.table.vgpu': 'vGPU',
+  'models.table.vgpu.slice': '{memory}% 显存 / {cores}% 算力',
   'models.table.backend': '后端',
   'models.table.acrossworker': '跨节点推理',
   'models.table.cpuoffload': 'CPU 卸载',

--- a/src/pages/gpu-service/instance-types/config/types.ts
+++ b/src/pages/gpu-service/instance-types/config/types.ts
@@ -30,6 +30,7 @@ export interface InstanceTypeStatus {
   accelerator?: InstanceTypeResource | null;
   acceleratorShared?: InstanceTypeResource | null;
   acceleratorSliced?: InstanceTypeResource | null;
+  acceleratorPartitioned?: InstanceTypeResource | null;
   cpu?: InstanceTypeResource | null;
 }
 

--- a/src/pages/llmodels/components/deployment/update-modal.tsx
+++ b/src/pages/llmodels/components/deployment/update-modal.tsx
@@ -180,8 +180,11 @@ const UpdateModal: React.FC<AddModalProps> = (props) => {
     const isVoxBox = [backendOptionsMap.voxBox].includes(formdata.backend);
 
     submitData = {
-      ..._.omit(formdata, ['scheduleType']),
+      ..._.omit(formdata, ['scheduleType', 'manualGpuMode']),
       worker_selector:
+        // Manual picks the GPUs itself — whole cards via gpu_selector or an
+        // InstanceType pool via gpu_type_selector — so neither carries a
+        // stale worker_selector.
         formdata.scheduleType === ScheduleValueMap.Manual
           ? null
           : formdata.worker_selector,

--- a/src/pages/llmodels/components/instance-cells/distribute-info-cell.tsx
+++ b/src/pages/llmodels/components/instance-cells/distribute-info-cell.tsx
@@ -14,8 +14,11 @@ import styled from 'styled-components';
 import {
   DistributedServerItem,
   DistributedServers,
+  GPUTypeSelector,
   ModelInstanceListItem
 } from '../../config/types';
+import { useGPUTypeDisplayName } from '../../hooks/use-gpu-type-display-name';
+import { formatGPUTypeAllocation } from './vgpu-info';
 
 const GPUIndexWrapper = styled.span`
   display: flex;
@@ -26,6 +29,10 @@ const GPUIndexWrapper = styled.span`
 interface DistributeInfoCellProps {
   record: ModelInstanceListItem;
   workerList: WorkerListItem[];
+  // The parent model's gpu_type_selector; when set (vGPU deployment) the
+  // tooltip table gains a vGPU column. Same for every worker — each holds
+  // one slice of the same InstanceType.
+  gpuTypeSelector?: GPUTypeSelector | null;
 }
 
 const renderGpuIndexs = (gpuIndexes: number[]) => {
@@ -85,12 +92,42 @@ const calcTotalVram = (vram: Record<string, number>) => {
 
 const DistributedServerList: React.FC<DistributeInfoCellProps> = ({
   record,
-  workerList
+  workerList,
+  gpuTypeSelector
 }) => {
-  const severList: DistributedServerItem[] =
+  const intl = useIntl();
+  const serverList: DistributedServerItem[] =
     record?.distributed_servers?.subordinate_workers || [];
 
-  const list = _.map(severList, (item: any) => {
+  // vGPU allocation label (e.g. "A10 (1g.2gb)"); empty for non-vGPU models,
+  // in which case the table renders exactly as before (no extra column).
+  const gpuTypeDisplayName = useGPUTypeDisplayName(
+    record?.cluster_id,
+    gpuTypeSelector?.type
+  );
+  const vgpuAllocation = formatGPUTypeAllocation(
+    intl,
+    gpuTypeSelector,
+    gpuTypeDisplayName
+  );
+
+  const columns = React.useMemo(() => {
+    if (!vgpuAllocation) {
+      return distributeCols;
+    }
+    const vgpuCol: ColumnProps = {
+      title: 'models.table.vgpu',
+      locale: true,
+      key: 'vgpu',
+      style: {
+        wordBreak: 'break-word'
+      }
+    };
+    // Insert after the GPU index column, before allocated VRAM.
+    return [...distributeCols.slice(0, 3), vgpuCol, ...distributeCols.slice(3)];
+  }, [vgpuAllocation]);
+
+  const list = _.map(serverList, (item: DistributedServerItem) => {
     const data = _.find(workerList, { id: item.worker_id });
     return {
       worker_name: data?.name,
@@ -100,7 +137,8 @@ const DistributedServerList: React.FC<DistributeInfoCellProps> = ({
       vram: calcTotalVram(item.computed_resource_claim?.vram || {}),
       gpu_index: _.keys(item.computed_resource_claim?.vram)
         .map((i: string) => Number(i))
-        .sort((a: number, b: number) => a - b)
+        .sort((a: number, b: number) => a - b),
+      vgpu: vgpuAllocation
     };
   });
 
@@ -111,7 +149,8 @@ const DistributedServerList: React.FC<DistributeInfoCellProps> = ({
       port: '',
       vram: calcTotalVram(record.computed_resource_claim?.vram || {}),
       is_main: true,
-      gpu_index: record.gpu_indexes?.sort((a: number, b: number) => a - b)
+      gpu_index: record.gpu_indexes?.sort((a: number, b: number) => a - b),
+      vgpu: vgpuAllocation
     }
   ];
 
@@ -119,7 +158,7 @@ const DistributedServerList: React.FC<DistributeInfoCellProps> = ({
     <div>
       <SimpleTable
         rowKey="worker_name"
-        columns={distributeCols}
+        columns={columns}
         dataSource={[...mainWorker, ...list]}
       ></SimpleTable>
     </div>
@@ -129,15 +168,16 @@ const DistributedServerList: React.FC<DistributeInfoCellProps> = ({
 const DistributeInfoCell: React.FC<{
   record: ModelInstanceListItem;
   workerList: WorkerListItem[];
-}> = ({ record, workerList }) => {
+  gpuTypeSelector?: GPUTypeSelector | null;
+}> = ({ record, workerList, gpuTypeSelector }) => {
   const intl = useIntl();
   const distributed_servers: DistributedServers | undefined =
     record?.distributed_servers;
 
-  const severList: DistributedServerItem[] =
+  const serverList: DistributedServerItem[] =
     distributed_servers?.subordinate_workers || [];
 
-  if (!severList.length) {
+  if (!serverList.length) {
     return null;
   }
   return (
@@ -155,6 +195,7 @@ const DistributeInfoCell: React.FC<{
         <DistributedServerList
           record={record}
           workerList={workerList}
+          gpuTypeSelector={gpuTypeSelector}
         ></DistributedServerList>
       }
     >

--- a/src/pages/llmodels/components/instance-cells/name-cell.tsx
+++ b/src/pages/llmodels/components/instance-cells/name-cell.tsx
@@ -2,6 +2,7 @@ import { convertFileSize } from '@/utils';
 import {
   HddFilled,
   InfoCircleOutlined,
+  PartitionOutlined,
   PieChartFilled,
   ThunderboltFilled
 } from '@ant-design/icons';
@@ -11,7 +12,13 @@ import { Tooltip } from 'antd';
 import _ from 'lodash';
 import React, { useEffect } from 'react';
 import { ModelInstanceListItem } from '../../config/types';
+import { useGPUTypeDisplayName } from '../../hooks/use-gpu-type-display-name';
 import '../../style/instance-item.less';
+import {
+  formatGPUTypeAllocation,
+  getGPUTypeClusterId,
+  getGPUTypeSelector
+} from './vgpu-info';
 export interface NameCellProps {
   record: ModelInstanceListItem;
   modelData: any;
@@ -34,6 +41,17 @@ const WorkerInfoContent: React.FC<NameCellProps> = ({ record, modelData }) => {
       ? `${record.worker_ip}:${record.port}`
       : record.worker_ip;
   }
+  // vGPU (InstanceType) allocation; empty for non-vGPU instances.
+  const gpuTypeSelector = getGPUTypeSelector(record, modelData);
+  const gpuTypeDisplayName = useGPUTypeDisplayName(
+    getGPUTypeClusterId(record, modelData),
+    gpuTypeSelector?.type
+  );
+  const vgpuAllocation = formatGPUTypeAllocation(
+    intl,
+    gpuTypeSelector,
+    gpuTypeDisplayName
+  );
   return (
     <div>
       <div>{record.worker_name}</div>
@@ -50,6 +68,12 @@ const WorkerInfoContent: React.FC<NameCellProps> = ({ record, modelData }) => {
         )}
         ]
       </div>
+      {vgpuAllocation && (
+        <div className="flex-center">
+          <PartitionOutlined className="m-r-5" />
+          {intl.formatMessage({ id: 'models.table.vgpu' })}: {vgpuAllocation}
+        </div>
+      )}
       <div className="flex-center">
         <ThunderboltFilled className="m-r-5" />
         {intl.formatMessage({ id: 'models.form.backend' })}:{' '}

--- a/src/pages/llmodels/components/instance-cells/vgpu-info.ts
+++ b/src/pages/llmodels/components/instance-cells/vgpu-info.ts
@@ -1,0 +1,69 @@
+import _ from 'lodash';
+import { GPUTypeSelector, ModelInstanceListItem } from '../../config/types';
+
+// Minimal shape of the useIntl() result we depend on — keeps this module
+// free of an intl package import (mirrors gpu-service render-instance-type).
+type IntlLike = {
+  formatMessage: (
+    descriptor: { id: string },
+    values?: Record<string, any>
+  ) => string;
+};
+
+// A vGPU instance is one whose model carries a gpu_type_selector (deployed
+// via an InstanceType). The selector is model-level and identical for all of
+// the model's instances — each worker holds one slice of the same type — so
+// it is read off the parent model; the instance's own echo (if the API ever
+// provides one) takes precedence.
+export const getGPUTypeSelector = (
+  record: ModelInstanceListItem,
+  modelData?: any
+): GPUTypeSelector | null | undefined => {
+  return record?.gpu_type_selector || modelData?.gpu_type_selector;
+};
+
+// The cluster whose instance types the selector's `type` names — needed to
+// resolve its display name (see useGPUTypeDisplayName). Read off the instance,
+// falling back to the parent model.
+export const getGPUTypeClusterId = (
+  record: ModelInstanceListItem,
+  modelData?: any
+): number | undefined => {
+  return record?.cluster_id ?? modelData?.cluster_id;
+};
+
+// Compact "<gpu type> (<allocation>)" label for an instance's vGPU allocation:
+// - partitioned: "<gpu type> (<profile>)" — hardware partition (e.g. MIG)
+// - sliced: "<gpu type> (<memory>% VRAM / <cores>% Compute)" — soft slice
+// - whole card from the type pool: "<gpu type> (Full GPU)"
+// The GPU type reads as its display name — the deployment records only the
+// type's name, so the caller resolves the display name and passes it in; it
+// falls back to the name while that is still loading, or when the type carries
+// none. Returns '' for non-vGPU instances so callers can gate rendering on it.
+export const formatGPUTypeAllocation = (
+  intl: IntlLike,
+  selector?: GPUTypeSelector | null,
+  typeDisplayName?: string
+): string => {
+  if (!selector?.type) {
+    return '';
+  }
+
+  const type = typeDisplayName || selector.type;
+  const profile = selector.accelerator_partitioned_profile;
+  if (profile) {
+    return `${type} (${profile})`;
+  }
+
+  const memory = _.toNumber(selector.accelerator_sliced_memory_percentage) || 0;
+  const cores = _.toNumber(selector.accelerator_sliced_cores_percentage) || 0;
+  if (memory > 0 || cores > 0) {
+    const slice = intl.formatMessage(
+      { id: 'models.table.vgpu.slice' },
+      { memory, cores }
+    );
+    return `${type} (${slice})`;
+  }
+
+  return `${type} (${intl.formatMessage({ id: 'gpuservice.instance.mode.whole' })})`;
+};

--- a/src/pages/llmodels/config/index.ts
+++ b/src/pages/llmodels/config/index.ts
@@ -219,6 +219,15 @@ export const ScheduleValueMap = {
   SpecificGPUType: 'specific_gpu_type'
 };
 
+// Manual scheduling picks the GPUs one of two ways, chosen by a tab: whole
+// cards out of the cluster's inventory (gpu_selector), or a whole / sliced /
+// partitioned GPU out of an InstanceType pool (gpu_type_selector, "vGPU").
+// UI-only field — the payload it maps to is one selector or the other.
+export const ManualGPUModeMap = {
+  FullGPU: 'full_gpu',
+  VGPU: 'vgpu'
+};
+
 export const scheduleList = [
   {
     label: 'models.form.scheduletype.auto',
@@ -396,6 +405,7 @@ export const DO_NOT_TRIGGER_CHECK_COMPATIBILITY = [
   'backend_version',
   'ollama_library_model_name',
   'scheduleType',
+  'manualGpuMode',
   'placement_strategy',
   'backend',
   'gpu_selector.gpu_ids',
@@ -417,6 +427,7 @@ export const defaultFormValues = {
   categories: null,
   env: {},
   scheduleType: ScheduleValueMap.Auto,
+  manualGpuMode: ManualGPUModeMap.FullGPU,
   placement_strategy: 'spread',
   gpu_ids: null,
   gpu_selector: {},

--- a/src/pages/llmodels/config/types.ts
+++ b/src/pages/llmodels/config/types.ts
@@ -48,7 +48,20 @@ export interface ListItem {
     gpu_ids: string[];
     gpus_per_replica?: number;
   };
+  gpu_type_selector?: GPUTypeSelector | null;
   worker_selector?: object;
+}
+
+// vGPU scheduling (issue #5192): deploy onto a GPU provided by a
+// gpustack-operator InstanceType. Mutually exclusive with `gpu_selector`.
+// Percentages 1-100 request a soft slice; both 0 request a whole card from
+// the type pool; `accelerator_partitioned_profile` requests a hardware
+// partition (e.g. MIG) and is mutually exclusive with the percentages.
+export interface GPUTypeSelector {
+  type?: string | null;
+  accelerator_sliced_memory_percentage?: number | null;
+  accelerator_sliced_cores_percentage?: number | null;
+  accelerator_partitioned_profile?: string | null;
 }
 
 export type DeployFormKey = 'deployment' | 'catalog';
@@ -98,10 +111,14 @@ export interface FormData {
     gpu_count?: number;
     gpus_per_replica?: number;
   };
+  gpu_type_selector?: GPUTypeSelector | null;
   placement_strategy?: string;
   cpu_offloading?: boolean;
   worker_selector?: object;
   scheduleType?: string;
+  // Which GPU source the manual mode picks from (ManualGPUModeMap): whole
+  // cards or an InstanceType pool. UI-only, stripped before submit.
+  manualGpuMode?: string;
   name: string;
   replicas: number;
   description: string;
@@ -149,7 +166,9 @@ interface ComputedResourceClaim {
 export interface DistributedServerItem {
   pid: number;
   port: number;
-  worker_id: string;
+  // Numeric on the wire (ModelInstanceSubordinateWorker.worker_id), so it
+  // matches a worker's `id` by identity in the worker-list lookup.
+  worker_id: number;
   computed_resource_claim: ComputedResourceClaim;
 }
 
@@ -176,6 +195,9 @@ export interface ModelInstanceListItem {
   gpu_indexes?: number[];
   worker_ip: string;
   gpu_index: number;
+  // Echoed from the parent Model when it was deployed via an InstanceType
+  // (vGPU); drives the slice/partition display on the instance row.
+  gpu_type_selector?: GPUTypeSelector | null;
   pid: number;
   port: number;
   name: string;

--- a/src/pages/llmodels/forms/basic.tsx
+++ b/src/pages/llmodels/forms/basic.tsx
@@ -78,6 +78,7 @@ interface BasicFormProps {
       provider: string;
       state: string;
       is_default: boolean;
+      gpu_instance_enabled?: boolean;
       owner_principal_id?: number;
       workers: number;
       ready_workers: number;

--- a/src/pages/llmodels/forms/index.tsx
+++ b/src/pages/llmodels/forms/index.tsx
@@ -19,6 +19,7 @@ import {
   DeployFormKeyMap,
   DO_NOT_NOTIFY_RECREATE,
   DO_NOT_TRIGGER_CHECK_COMPATIBILITY,
+  ManualGPUModeMap,
   modelSourceMap,
   ScheduleValueMap
 } from '../config';
@@ -45,7 +46,11 @@ const baseRequiredFields = ['name', 'source'];
 
 const advancedRequiredFields = ['backend', 'image_name', 'run_command'];
 
-const scheduleRequiredFields = ['gpu_selector', 'scaling_schedule'];
+const scheduleRequiredFields = [
+  'gpu_selector',
+  'gpu_type_selector',
+  'scaling_schedule'
+];
 
 const performanceRequiredFields = ['speculative_config'];
 
@@ -230,7 +235,7 @@ const DataForm: React.FC<DataFormProps> = forwardRef((props, ref) => {
     }
     const gpuSelector = generateGPUIds(data);
     const allValues = {
-      ..._.omit(data, ['scheduleType']),
+      ..._.omit(data, ['scheduleType', 'manualGpuMode']),
       ...gpuSelector
     };
     // Don't persist a disabled schedule — send null so the model carries no
@@ -248,13 +253,15 @@ const DataForm: React.FC<DataFormProps> = forwardRef((props, ref) => {
   };
 
   // Shared work when the target cluster changes: refetch the GPU/backend
-  // options for the new cluster and reset schedule/gpu selection.
+  // options for the new cluster and reset the per-cluster GPU selections.
+  // The schedule mode itself is kept: switching cluster must not kick a
+  // vGPU-mode form back to Auto (the auto-seed fires exactly on that path).
   const applyClusterScopedOptions = (value: number) => {
     getGPUOptionList({ clusterId: value });
     getBackendOptions({ cluster_id: value });
     form.setFieldsValue({
-      scheduleType: ScheduleValueMap.Auto,
-      gpu_selector: null
+      gpu_selector: null,
+      gpu_type_selector: null
     });
   };
 
@@ -462,6 +469,7 @@ const DataForm: React.FC<DataFormProps> = forwardRef((props, ref) => {
             source: props.source,
             placement_strategy: 'spread',
             scheduleType: ScheduleValueMap.Auto,
+            manualGpuMode: ManualGPUModeMap.FullGPU,
             categories: null,
             restart_on_error: true,
             distributed_inference_across_workers: true,

--- a/src/pages/llmodels/forms/schedule-type.tsx
+++ b/src/pages/llmodels/forms/schedule-type.tsx
@@ -7,12 +7,14 @@ import {
   useAppUtils
 } from '@gpustack/core-ui';
 import { useIntl } from '@umijs/max';
-import { Form, InputNumber } from 'antd';
+import { Flex, Form, InputNumber, Segmented } from 'antd';
+import { createStyles } from 'antd-style';
 import _ from 'lodash';
 import React from 'react';
 import styled from 'styled-components';
 import GPUCard from '../components/gpu-card';
 import {
+  ManualGPUModeMap,
   placementStrategyOptions,
   scheduleList,
   ScheduleValueMap
@@ -21,10 +23,27 @@ import { useFormContext } from '../config/form-context';
 import { FormData } from '../config/types';
 import { backendOptionsMap } from '../constants/backend-parameters';
 import '../style/gpu-selector.less';
+import VGPUTypeForm from './vgpu-type';
 
 const InputWrapper = styled.div`
   padding: 8px 4px;
 `;
+
+// The manual mode's GPU source lives in a bordered section whose switch sits in
+// the title row, mirroring the Scheduled Scaling section of the same form.
+const useStyles = createStyles(({ css }) => ({
+  sectionCard: css`
+    border: 1px solid var(--ant-color-border);
+    border-radius: 8px;
+    padding: 16px 12px 4px;
+    margin-bottom: 8px;
+    .section-title {
+      margin-bottom: 12px;
+      font-size: 14px;
+      color: var(--ant-color-text);
+    }
+  `
+}));
 
 const placementStrategyTips = [
   {
@@ -66,6 +85,7 @@ const GPUsPerReplicaTips = [
 
 const ScheduleTypeForm: React.FC = () => {
   const intl = useIntl();
+  const { styles } = useStyles();
   const {
     onValuesChange,
     action,
@@ -77,10 +97,33 @@ const ScheduleTypeForm: React.FC = () => {
   const { getRuleMessage } = useAppUtils();
   const form = Form.useFormInstance();
   const scheduleType = Form.useWatch('scheduleType', form);
+  const manualGpuMode = Form.useWatch('manualGpuMode', form);
   const GPUsPerReplicas = Form.useWatch(
     ['gpu_selector', 'gpus_per_replica'],
     form
   );
+
+  // Single commit path for the Full GPU / vGPU tab: the two GPU sources are
+  // mutually exclusive, so seed the one the tab owns and null the other —
+  // otherwise the abandoned tab's selector rides the submit.
+  const commitManualGpuMode = (mode: string) => {
+    form.setFieldValue('manualGpuMode', mode);
+    if (mode === ManualGPUModeMap.VGPU) {
+      form.setFieldValue('gpu_selector', null);
+      form.setFieldValue('gpu_type_selector', {
+        type: null,
+        accelerator_sliced_memory_percentage: 0,
+        accelerator_sliced_cores_percentage: 0,
+        accelerator_partitioned_profile: null
+      });
+    } else {
+      form.setFieldValue('gpu_selector', {
+        gpu_ids: [],
+        gpus_per_replica: null
+      });
+      form.setFieldValue('gpu_type_selector', null);
+    }
+  };
 
   const handleScheduleTypeChange = async (value: string) => {
     await new Promise((resolve) => {
@@ -88,12 +131,14 @@ const ScheduleTypeForm: React.FC = () => {
     });
 
     if (value === ScheduleValueMap.Auto) {
+      form.setFieldValue('gpu_selector', null);
+      form.setFieldValue('gpu_type_selector', null);
       onValuesChange?.({}, form.getFieldsValue());
     } else if (value === ScheduleValueMap.Manual) {
-      form.setFieldValue('gpu_selector', {
-        gpu_ids: [],
-        gpus_per_replica: null
-      });
+      // Entering manual seeds whichever source its tab currently points at.
+      commitManualGpuMode(
+        form.getFieldValue('manualGpuMode') || ManualGPUModeMap.FullGPU
+      );
     }
   };
 
@@ -162,93 +207,142 @@ const ScheduleTypeForm: React.FC = () => {
       )}
       {scheduleType === ScheduleValueMap.Manual &&
         !form.getFieldValue('fix_gpu_type') && (
-          <>
-            <Form.Item
-              data-field="gpu_selector.gpu_ids"
-              name={['gpu_selector', 'gpu_ids']}
-              rules={[
-                {
-                  required: true,
-                  message: getRuleMessage('select', 'models.form.gpuselector')
-                }
-              ]}
+          <div className={styles.sectionCard}>
+            {/* Which GPU source manual scheduling picks from: whole cards out
+              of the cluster's inventory, or a slice of a GPU out of an
+              InstanceType pool (vGPU), where the slice request lives. */}
+            <Flex
+              className="section-title"
+              align="center"
+              justify="space-between"
             >
-              <SealCascader
-                required
-                showSearch
-                expandTrigger="click"
-                multiple={
-                  form.getFieldValue('backend') !== backendOptionsMap.voxBox
-                }
-                classNames={{
-                  popup: {
-                    root: 'cascader-popup-wrapper gpu-selector'
-                  }
-                }}
-                styles={{
-                  popup: {
-                    listItem: {
-                      maxWidth: 'unset'
+              <span>
+                {intl.formatMessage({ id: 'models.form.gpuallocation' })}
+              </span>
+              <Form.Item name="manualGpuMode" noStyle>
+                <Segmented
+                  size="middle"
+                  type="rounded"
+                  style={{ fontSize: 12 }}
+                  onChange={commitManualGpuMode}
+                  options={[
+                    {
+                      label: intl.formatMessage({
+                        id: 'models.form.gpumode.full'
+                      }),
+                      value: ManualGPUModeMap.FullGPU
+                    },
+                    {
+                      label: intl.formatMessage({
+                        id: 'models.form.gpumode.slicing'
+                      }),
+                      value: ManualGPUModeMap.VGPU
                     }
-                  }
-                }}
-                maxTagCount={1}
-                label={intl.formatMessage({ id: 'models.form.gpuselector' })}
-                options={gpuOptions}
-                showCheckedStrategy="SHOW_CHILD"
-                value={form.getFieldValue(['gpu_selector', 'gpu_ids'])}
-                optionNode={GPUCard}
-                getPopupContainer={(triggerNode) => triggerNode.parentNode}
-                notFoundContent={intl.formatMessage({
-                  id: 'models.form.gpus.notfound'
-                })}
-                onChange={handleGpuSelectorChange}
-              ></SealCascader>
-            </Form.Item>
-            <Form.Item name={['gpu_selector', 'gpus_per_replica']}>
-              <SealSelect
-                label={intl.formatMessage({
-                  id: 'models.form.gpusperreplica'
-                })}
-                allowNull
-                options={[
-                  {
-                    label: intl.formatMessage({ id: 'common.options.auto' }),
-                    value: null
-                  },
-                  { label: '1', value: 1 },
-                  { label: '2', value: 2 },
-                  { label: '4', value: 4 },
-                  { label: '8', value: 8 },
-                  { label: '16', value: 16 }
-                ]}
-                description={
-                  <TooltipList list={GPUsPerReplicaTips}></TooltipList>
-                }
-                popupRender={(originNode) => (
-                  <div>
-                    {originNode}
-                    <InputWrapper>
-                      <InputNumber
-                        min={1}
-                        max={64}
-                        step={1}
-                        style={{ width: '100%' }}
-                        defaultValue={
-                          GPUsPerReplicas === -1 ? null : GPUsPerReplicas
+                  ]}
+                />
+              </Form.Item>
+            </Flex>
+            {manualGpuMode === ManualGPUModeMap.VGPU ? (
+              <VGPUTypeForm />
+            ) : (
+              <>
+                <Form.Item
+                  data-field="gpu_selector.gpu_ids"
+                  name={['gpu_selector', 'gpu_ids']}
+                  rules={[
+                    {
+                      required: true,
+                      message: getRuleMessage(
+                        'select',
+                        'models.form.gpuselector'
+                      )
+                    }
+                  ]}
+                >
+                  <SealCascader
+                    required
+                    showSearch
+                    expandTrigger="click"
+                    multiple={
+                      form.getFieldValue('backend') !== backendOptionsMap.voxBox
+                    }
+                    classNames={{
+                      popup: {
+                        root: 'cascader-popup-wrapper gpu-selector'
+                      }
+                    }}
+                    styles={{
+                      popup: {
+                        listItem: {
+                          maxWidth: 'unset'
                         }
-                        placeholder={intl.formatMessage({
-                          id: 'models.form.gpuPerReplica.tips'
-                        })}
-                        value={GPUsPerReplicas === -1 ? null : GPUsPerReplicas}
-                        onChange={handleGpusPerReplicasChange}
-                      />
-                    </InputWrapper>
-                  </div>
-                )}
-              />
-            </Form.Item>
-          </>
+                      }
+                    }}
+                    maxTagCount={1}
+                    label={intl.formatMessage({
+                      id: 'models.form.gpuselector'
+                    })}
+                    options={gpuOptions}
+                    showCheckedStrategy="SHOW_CHILD"
+                    value={form.getFieldValue(['gpu_selector', 'gpu_ids'])}
+                    optionNode={GPUCard}
+                    getPopupContainer={(triggerNode) => triggerNode.parentNode}
+                    notFoundContent={intl.formatMessage({
+                      id: 'models.form.gpus.notfound'
+                    })}
+                    onChange={handleGpuSelectorChange}
+                  ></SealCascader>
+                </Form.Item>
+                <Form.Item name={['gpu_selector', 'gpus_per_replica']}>
+                  <SealSelect
+                    label={intl.formatMessage({
+                      id: 'models.form.gpusperreplica'
+                    })}
+                    allowNull
+                    options={[
+                      {
+                        label: intl.formatMessage({
+                          id: 'common.options.auto'
+                        }),
+                        value: null
+                      },
+                      { label: '1', value: 1 },
+                      { label: '2', value: 2 },
+                      { label: '4', value: 4 },
+                      { label: '8', value: 8 },
+                      { label: '16', value: 16 }
+                    ]}
+                    description={
+                      <TooltipList list={GPUsPerReplicaTips}></TooltipList>
+                    }
+                    popupRender={(originNode) => (
+                      <div>
+                        {originNode}
+                        <InputWrapper>
+                          <InputNumber
+                            min={1}
+                            max={64}
+                            step={1}
+                            style={{ width: '100%' }}
+                            defaultValue={
+                              GPUsPerReplicas === -1 ? null : GPUsPerReplicas
+                            }
+                            placeholder={intl.formatMessage({
+                              id: 'models.form.gpuPerReplica.tips'
+                            })}
+                            value={
+                              GPUsPerReplicas === -1 ? null : GPUsPerReplicas
+                            }
+                            onChange={handleGpusPerReplicasChange}
+                          />
+                        </InputWrapper>
+                      </div>
+                    )}
+                  />
+                </Form.Item>
+              </>
+            )}
+          </div>
         )}
       {scheduleType === ScheduleValueMap.Auto && (
         <>

--- a/src/pages/llmodels/forms/vgpu-type.tsx
+++ b/src/pages/llmodels/forms/vgpu-type.tsx
@@ -1,0 +1,609 @@
+import NumberSelection from '@/pages/_components/number-selection';
+import { queryGPUInstanceTypes } from '@/pages/gpu-service/instance-types/apis';
+import { ListItem as InstanceTypeListItem } from '@/pages/gpu-service/instance-types/config/types';
+import {
+  formatMemoryDisplay,
+  getPartitionProfiles,
+  isLogicalSliceable,
+  isPhysicalSliceable
+} from '@/pages/gpu-service/instances/config';
+import { manufactureColorMap } from '@/pages/gpu-service/templates/config';
+import { formatManufacturer } from '@/pages/gpu-service/utils';
+import {
+  AutoTooltip,
+  Select as SealSelect,
+  ThemeTag,
+  useAppUtils
+} from '@gpustack/core-ui';
+import { useIntl } from '@umijs/max';
+import { Flex, Form, Input, InputNumber, Segmented } from 'antd';
+import _ from 'lodash';
+import React, { useEffect, useMemo, useState } from 'react';
+import { FormData } from '../config/types';
+
+// Percentage presets for the sliced (percentage) mode, mirroring the
+// GPU-instance form.
+const SLICE_PERCENT_TICKS = [10, 20, 30, 50];
+
+type SliceMode = 'whole' | 'sliced' | 'partitioned';
+
+// Derive the mode from the persisted selector values (edit hydration): a
+// partition profile means partitioned, positive percentages mean sliced,
+// anything else is a whole card.
+const getSliceModeFromValues = (selector: any): SliceMode => {
+  if (selector?.accelerator_partitioned_profile) {
+    return 'partitioned';
+  }
+  if (_.toNumber(selector?.accelerator_sliced_memory_percentage) > 0) {
+    return 'sliced';
+  }
+  return 'whole';
+};
+
+// Dropdown option for a GPU type: its display name, over the hardware that
+// tells two types apart at a glance — vendor, VRAM and architecture. The
+// vendor and memory are observed (status.detail), the arch is definitional
+// (spec); any of them can be absent on a type the operator has not backfilled.
+const GPUTypeOption: React.FC<{ item: InstanceTypeListItem }> = ({ item }) => {
+  const detail = item.status?.detail;
+  const manufacturer = detail?.manufacturer || '';
+  const pieces = [
+    formatMemoryDisplay(detail?.memory ?? undefined),
+    item.spec?.arch
+  ].filter(Boolean);
+
+  return (
+    <Flex vertical gap={4} style={{ minWidth: 0, padding: '2px 0' }}>
+      <AutoTooltip ghost minWidth={20}>
+        {item.spec?.displayName || item.name}
+      </AutoTooltip>
+      <Flex
+        align="center"
+        gap={8}
+        style={{
+          minWidth: 0,
+          color: 'var(--ant-color-text-tertiary)',
+          fontSize: 12
+        }}
+      >
+        {manufacturer && (
+          <ThemeTag
+            color={manufactureColorMap[manufacturer] ?? 'purple'}
+            style={{ fontWeight: 400, marginInlineEnd: 0 }}
+          >
+            {formatManufacturer(manufacturer)}
+          </ThemeTag>
+        )}
+        {pieces.map((piece, index) => (
+          <React.Fragment key={piece}>
+            {(index > 0 || !!manufacturer) && (
+              <span style={{ color: 'var(--ant-color-text-quaternary)' }}>
+                ·
+              </span>
+            )}
+            <span>{piece}</span>
+          </React.Fragment>
+        ))}
+      </Flex>
+    </Flex>
+  );
+};
+
+/**
+ * vGPU scheduling section: pick an InstanceType from the cluster's synced
+ * gpu-instance-types (the CRD names the backend validates against), then
+ * request a soft slice (ByRatio, memory/cores percentages) or a hardware
+ * partition (ByProfile). The mode switch only appears when the selected type
+ * offers BOTH modes; a single offered mode renders directly, and a type with
+ * no slicing capability requests a whole card with no extra controls.
+ */
+const VGPUTypeForm: React.FC = () => {
+  const intl = useIntl();
+  const { getRuleMessage } = useAppUtils();
+  const form = Form.useFormInstance();
+  const [typeList, setTypeList] = useState<InstanceTypeListItem[]>([]);
+  const [sliceMode, setSliceMode] = useState<SliceMode>(() =>
+    getSliceModeFromValues(form.getFieldValue('gpu_type_selector'))
+  );
+
+  const clusterId = Form.useWatch('cluster_id', form);
+  const typeName = Form.useWatch(['gpu_type_selector', 'type'], form);
+  const slicedMemoryPercentage =
+    _.toNumber(
+      Form.useWatch(
+        ['gpu_type_selector', 'accelerator_sliced_memory_percentage'],
+        form
+      )
+    ) || 1;
+
+  useEffect(() => {
+    if (clusterId == null) {
+      setTypeList([]);
+      return;
+    }
+    let cancelled = false;
+    queryGPUInstanceTypes({ cluster_id: clusterId })
+      .then((res) => {
+        if (cancelled) return;
+        // Only accelerator (GPU) types can back a vGPU deployment.
+        setTypeList(
+          (res?.items || []).filter((item) => item.spec?.acceleratable)
+        );
+      })
+      .catch(() => {
+        // leave the list empty; the select shows its not-found content
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [clusterId]);
+
+  const selectedInstanceType = useMemo(
+    () => typeList.find((item) => item.name === typeName),
+    [typeList, typeName]
+  );
+
+  const slicedDetail = selectedInstanceType?.status?.detail?.slicedDetail;
+
+  // Max selectable ratio in sliced mode: status.acceleratorSliced
+  // .onceMaxRequest (a percentage). The sliced mode stays visible but
+  // unselectable when there is no sliced capacity.
+  const slicedMaxPercentage =
+    _.toNumber(
+      selectedInstanceType?.status?.acceleratorSliced?.onceMaxRequest
+    ) || 0;
+
+  // Whether the compute (cores) ratio may exceed the memory ratio. Without
+  // overcommit the cores ratio is locked to the memory ratio and the cores
+  // selector is hidden (a hidden field mirrors the memory value).
+  const coresOvercommit = !!slicedDetail?.logical?.coresPercentageOvercommit;
+
+  const partitionOptions = useMemo(
+    () =>
+      getPartitionProfiles(slicedDetail).map((profile) => ({
+        label: profile.name as string,
+        value: profile.name as string
+      })),
+    [slicedDetail]
+  );
+
+  const supportsSliced = isLogicalSliceable(slicedDetail);
+  const supportsPartitioned =
+    isPhysicalSliceable(slicedDetail) && partitionOptions.length > 0;
+  // Capability present, capacity gone: the type can be sliced, but its pool
+  // has no room to slice right now (onceMaxRequest is 0). Distinct from "not
+  // sliceable at all" — a partition request may still go through, so this only
+  // takes the ByRatio side out of service, never the switch.
+  const slicedCapacityExhausted = supportsSliced && slicedMaxPercentage <= 0;
+  // The same shape on the partition side: the type can be hardware-partitioned
+  // but the pool has no profile left to hand out.
+  //
+  // These two guards look interchangeable and are NOT — do not fold them into
+  // one branch. Both states would serialize as 0/0, i.e. a whole-card request,
+  // but the consequence differs:
+  //   - sliced: a software-slicing node (logical.count > 0) satisfies a
+  //     whole-card request, so the downgrade SUCCEEDS — the user asked for a
+  //     percentage and silently gets an entire card, losing the isolation this
+  //     feature exists for. That is the severe one.
+  //   - partitioned: a MIG-mode node reports logical: {} and does not satisfy
+  //     it, so the backend's Devices-based fit refuses the request. No wrong
+  //     resource is ever handed out; what is wrong is that the user only finds
+  //     out at scheduling time, via a message about no node having software
+  //     slicing enabled — the opposite of what they asked for. This guard
+  //     exists to surface the real reason early, not to prevent a bad
+  //     allocation.
+  const partitionProfilesExhausted =
+    isPhysicalSliceable(slicedDetail) && partitionOptions.length === 0;
+  // Per the vGPU contract: two modes exist (ByRatio / ByProfile). Show the
+  // switch only when the type offers both; a single offered mode renders
+  // directly, and neither means a whole card with no controls.
+  const showModeSwitch = supportsSliced && supportsPartitioned;
+
+  const typeOptions = useMemo(
+    () =>
+      typeList.map((item) => ({
+        label: item.spec?.displayName || item.name,
+        value: item.name,
+        instanceType: item
+      })),
+    [typeList]
+  );
+
+  // Single commit path for mode switches (form-patterns): write every
+  // mode-specific field together so no stale value from the previous mode
+  // rides the submit.
+  const commitSliceMode = (mode: SliceMode) => {
+    setSliceMode(mode);
+    const current = form.getFieldValue('gpu_type_selector') || {};
+    if (mode === 'sliced') {
+      // With no sliceable capacity left, seed no percentage at all: a value
+      // here could not validate against a max of 0, and a 0 would silently
+      // turn the request into a whole card.
+      const memory =
+        slicedMaxPercentage > 0 ? Math.min(50, slicedMaxPercentage) : null;
+      form.setFieldValue('gpu_type_selector', {
+        ...current,
+        accelerator_sliced_memory_percentage: memory,
+        accelerator_sliced_cores_percentage:
+          memory && coresOvercommit ? 100 : memory,
+        accelerator_partitioned_profile: null
+      });
+    } else if (mode === 'partitioned') {
+      form.setFieldValue('gpu_type_selector', {
+        ...current,
+        accelerator_sliced_memory_percentage: 0,
+        accelerator_sliced_cores_percentage: 0
+        // keep any previously picked profile; the required rule prompts
+        // otherwise (no silent fallback to the first profile)
+      });
+    } else {
+      form.setFieldValue('gpu_type_selector', {
+        ...current,
+        accelerator_sliced_memory_percentage: 0,
+        accelerator_sliced_cores_percentage: 0,
+        accelerator_partitioned_profile: null
+      });
+    }
+  };
+
+  // Force the mode when the selected type offers exactly one, and clear back
+  // to a whole-card request when it offers none. Both-offered keeps the
+  // user's current pick (default sliced via handleTypeChange).
+  useEffect(() => {
+    if (!selectedInstanceType) return;
+    if (supportsSliced && !supportsPartitioned && sliceMode !== 'sliced') {
+      commitSliceMode('sliced');
+    } else if (
+      supportsPartitioned &&
+      !supportsSliced &&
+      sliceMode !== 'partitioned'
+    ) {
+      commitSliceMode('partitioned');
+    } else if (
+      !supportsSliced &&
+      !supportsPartitioned &&
+      sliceMode !== 'whole'
+    ) {
+      commitSliceMode('whole');
+    }
+  }, [selectedInstanceType, supportsSliced, supportsPartitioned]);
+
+  // Named rather than inlined into the prop, matching clusterOptionRender in
+  // basic.tsx: an inline arrow in a render prop reads to eslint as a component
+  // defined during render.
+  const typeOptionRender = (option: any) => (
+    <GPUTypeOption item={option.data.instanceType} />
+  );
+
+  // Picking a type resets the request to the type's primary mode (sliced when
+  // offered, else partitioned, else whole): slice capabilities are per-type,
+  // so a mode/ratio/profile from another type may not apply.
+  const handleTypeChange = (name: string) => {
+    const next = typeList.find((item) => item.name === name);
+    const nextDetail = next?.status?.detail?.slicedDetail;
+    const nextMode: SliceMode = isLogicalSliceable(nextDetail)
+      ? 'sliced'
+      : isPhysicalSliceable(nextDetail)
+        ? 'partitioned'
+        : 'whole';
+    setSliceMode(nextMode);
+    const nextSlicedMax =
+      _.toNumber(next?.status?.acceleratorSliced?.onceMaxRequest) || 0;
+    // A sliced mode with no capacity left seeds no percentage (see
+    // commitSliceMode); the other modes request a whole card / a profile at 0.
+    const memory =
+      nextMode !== 'sliced'
+        ? 0
+        : nextSlicedMax > 0
+          ? Math.min(50, nextSlicedMax)
+          : null;
+    form.setFieldValue('gpu_type_selector', {
+      type: name,
+      accelerator_sliced_memory_percentage: memory,
+      accelerator_sliced_cores_percentage:
+        memory && nextDetail?.logical?.coresPercentageOvercommit ? 100 : memory,
+      accelerator_partitioned_profile: null
+    });
+  };
+
+  // Memory (VRAM) ratio changed — without cores overcommit the cores ratio is
+  // locked to it, so mirror the value into the hidden cores field.
+  const handleMemoryPercentageChange = (value: number) => {
+    if (!coresOvercommit) {
+      form.setFieldValue(
+        ['gpu_type_selector', 'accelerator_sliced_cores_percentage'],
+        value
+      );
+    }
+  };
+
+  // When the max ratio is below 10%, switch the ticks to a finer 1..10 scale
+  // so small slices are still selectable; otherwise use the 10..100 scale.
+  const sliceTicks: number[] =
+    slicedMaxPercentage < 10
+      ? [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+      : SLICE_PERCENT_TICKS;
+
+  const isSliced = sliceMode === 'sliced' && supportsSliced;
+  const isPartitioned = sliceMode === 'partitioned' && supportsPartitioned;
+
+  return (
+    <div data-field="gpuTypeSelector">
+      <Form.Item<FormData>
+        name={['gpu_type_selector', 'type']}
+        rules={[
+          {
+            required: true,
+            message: getRuleMessage('select', 'models.form.gpuType')
+          }
+        ]}
+      >
+        <SealSelect
+          showSearch
+          label={intl.formatMessage({ id: 'models.form.gpuType' })}
+          options={typeOptions}
+          optionRender={typeOptionRender}
+          onChange={handleTypeChange}
+          notFoundContent={intl.formatMessage({
+            id: 'gpuservice.instance.type.noAvailable'
+          })}
+        ></SealSelect>
+      </Form.Item>
+      {showModeSwitch && (
+        <div style={{ marginBlock: 8 }}>
+          <Segmented
+            size="middle"
+            type="rounded"
+            style={{ fontSize: 12 }}
+            value={sliceMode}
+            onChange={(value) => commitSliceMode(value as SliceMode)}
+            options={[
+              {
+                label: intl.formatMessage({
+                  id: 'gpuservice.instance.mode.sliced'
+                }),
+                value: 'sliced',
+                disabled: slicedMaxPercentage <= 0
+              },
+              {
+                label: intl.formatMessage({
+                  id: 'gpuservice.instance.mode.partitioned'
+                }),
+                value: 'partitioned',
+                disabled: partitionOptions.length === 0
+              }
+            ]}
+          />
+        </div>
+      )}
+      {isSliced && slicedCapacityExhausted && (
+        <>
+          <div
+            style={{
+              marginBlock: 8,
+              color: 'var(--ant-color-text-tertiary)'
+            }}
+          >
+            {intl.formatMessage({ id: 'models.form.gpuType.noSlicedCapacity' })}
+          </div>
+          {/* Nothing here can be submitted: with no capacity there is no valid
+            percentage, and a 0 would degrade the request to a whole card.
+            Seeding null above is NOT enough on its own — generateGPUTypeSelector
+            normalizes it straight back with `_.toNumber(...) || 0`, so the
+            payload would be 0/0 either way. This rule is what actually stops
+            the submit: load-bearing, not belt-and-braces, so don't drop it as
+            redundant. Keeping it mounted also makes the failure name the reason
+            above instead of "cannot exceed 0%"; it unmounts — and the error
+            clears — as soon as the user switches to ByProfile, which stays
+            submittable. */}
+          <Form.Item<FormData>
+            name={['gpu_type_selector', 'accelerator_sliced_memory_percentage']}
+            rules={[
+              {
+                validator: () =>
+                  Promise.reject(
+                    new Error(
+                      intl.formatMessage({
+                        id: 'models.form.gpuType.noSlicedCapacity'
+                      })
+                    )
+                  )
+              }
+            ]}
+            hidden
+          >
+            <InputNumber />
+          </Form.Item>
+        </>
+      )}
+      {isSliced && !slicedCapacityExhausted && (
+        <>
+          <Form.Item<FormData>
+            name={['gpu_type_selector', 'accelerator_sliced_memory_percentage']}
+            getValueProps={(value) => ({
+              value: value != null ? _.toNumber(value) : undefined
+            })}
+            rules={[
+              {
+                required: true,
+                validator: (_, value) => {
+                  const num = Number(value);
+                  if (value == null || value === '' || Number.isNaN(num)) {
+                    return Promise.reject(
+                      new Error(
+                        intl.formatMessage({
+                          id: 'gpuservice.instance.slice.percentage.required'
+                        })
+                      )
+                    );
+                  }
+                  if (num > slicedMaxPercentage || num <= 0) {
+                    return Promise.reject(
+                      new Error(
+                        intl.formatMessage(
+                          { id: 'gpuservice.instance.slice.percentage.max' },
+                          { count: slicedMaxPercentage }
+                        )
+                      )
+                    );
+                  }
+                  return Promise.resolve();
+                }
+              }
+            ]}
+          >
+            <NumberSelection
+              min={1}
+              max={slicedMaxPercentage}
+              step={1}
+              maxCount={sliceTicks.length}
+              presetValues={sliceTicks}
+              alwaysShowInput
+              required
+              onChange={handleMemoryPercentageChange}
+              label={intl.formatMessage({
+                // Without cores overcommit this single ratio drives both VRAM
+                // and compute, so drop the "VRAM" qualifier.
+                id: coresOvercommit
+                  ? 'gpuservice.instance.slice.memoryPercentage'
+                  : 'gpuservice.instance.slice.percentage'
+              })}
+            />
+          </Form.Item>
+          {/* Compute (cores) ratio — only types with cores overcommit get the
+            selector; otherwise it is locked to the memory ratio and carried by
+            a hidden field so it still rides the submit. */}
+          {coresOvercommit ? (
+            <Form.Item<FormData>
+              name={[
+                'gpu_type_selector',
+                'accelerator_sliced_cores_percentage'
+              ]}
+              getValueProps={(value) => ({
+                value: value != null ? _.toNumber(value) : undefined
+              })}
+              rules={[
+                {
+                  required: true,
+                  validator: (_, value) => {
+                    const num = Number(value);
+                    if (value == null || value === '' || Number.isNaN(num)) {
+                      return Promise.reject(
+                        new Error(
+                          intl.formatMessage({
+                            id: 'gpuservice.instance.slice.percentage.required'
+                          })
+                        )
+                      );
+                    }
+                    if (num < slicedMemoryPercentage || num > 100) {
+                      return Promise.reject(
+                        new Error(
+                          intl.formatMessage(
+                            { id: 'gpuservice.instance.slice.cores.min' },
+                            { count: slicedMemoryPercentage }
+                          )
+                        )
+                      );
+                    }
+                    return Promise.resolve();
+                  }
+                }
+              ]}
+            >
+              <NumberSelection
+                min={slicedMemoryPercentage}
+                max={100}
+                step={10}
+                maxCount={SLICE_PERCENT_TICKS.length}
+                presetValues={SLICE_PERCENT_TICKS}
+                alwaysShowInput
+                required
+                label={intl.formatMessage({
+                  id: 'gpuservice.instance.slice.coresPercentage'
+                })}
+              />
+            </Form.Item>
+          ) : (
+            <Form.Item<FormData>
+              name={[
+                'gpu_type_selector',
+                'accelerator_sliced_cores_percentage'
+              ]}
+              hidden
+            >
+              <InputNumber />
+            </Form.Item>
+          )}
+        </>
+      )}
+      {isPartitioned && (
+        <Form.Item<FormData>
+          name={['gpu_type_selector', 'accelerator_partitioned_profile']}
+          rules={[
+            {
+              required: true,
+              message: intl.formatMessage({
+                id: 'gpuservice.instance.partition.profile.required'
+              })
+            }
+          ]}
+        >
+          <SealSelect
+            required
+            options={partitionOptions}
+            label={intl.formatMessage({
+              id: 'gpuservice.instance.partition.profile'
+            })}
+          ></SealSelect>
+        </Form.Item>
+      )}
+      {/* Takes the profile picker's place when the pool has no profile left and
+        there is no ratio side to fall back to. Not gated on sliceMode: with no
+        profiles `supportsPartitioned` is false, so ByProfile is neither
+        selectable (the switch collapses) nor sticky (the mode effect lands on
+        `whole`) — gating on the mode would render nothing at all. When ratio
+        slicing IS offered the user is already on a working ByRatio, so this
+        stays quiet rather than warning about a mode they cannot reach. */}
+      {partitionProfilesExhausted && !supportsSliced && (
+        <>
+          <div
+            style={{
+              marginBlock: 8,
+              color: 'var(--ant-color-text-tertiary)'
+            }}
+          >
+            {intl.formatMessage({
+              id: 'models.form.gpuType.noPartitionProfile'
+            })}
+          </div>
+          {/* Same mounted rule as the ByRatio side, load-bearing for the same
+            reason: a null profile plus generateGPUTypeSelector's
+            `_.toNumber(...) || 0` percentages serialize as 0/0 — a whole card
+            the scheduler rejects much later, citing software slicing rather
+            than the missing profile. */}
+          <Form.Item<FormData>
+            name={['gpu_type_selector', 'accelerator_partitioned_profile']}
+            rules={[
+              {
+                validator: () =>
+                  Promise.reject(
+                    new Error(
+                      intl.formatMessage({
+                        id: 'models.form.gpuType.noPartitionProfile'
+                      })
+                    )
+                  )
+              }
+            ]}
+            hidden
+          >
+            <Input />
+          </Form.Item>
+        </>
+      )}
+    </div>
+  );
+};
+
+export default VGPUTypeForm;

--- a/src/pages/llmodels/hooks/index.ts
+++ b/src/pages/llmodels/hooks/index.ts
@@ -204,7 +204,11 @@ export const useCheckCompatibility = () => {
               // scaling_schedule has no bearing on resource/compatibility
               // evaluation; drop it so in-progress (possibly incomplete) rules
               // never fail the evaluate request.
-              ..._.omit(data, ['scheduleType', 'scaling_schedule']),
+              ..._.omit(data, [
+                'scheduleType',
+                'manualGpuMode',
+                'scaling_schedule'
+              ]),
               categories: Array.isArray(data.categories)
                 ? data.categories
                 : data.categories

--- a/src/pages/llmodels/hooks/use-form-initial-values.ts
+++ b/src/pages/llmodels/hooks/use-form-initial-values.ts
@@ -10,7 +10,7 @@ import { ListItem as WorkerListItem } from '@/pages/resources/config/types';
 import { useAtom } from 'jotai';
 import { useState } from 'react';
 import { queryGPUList } from '../apis';
-import { ScheduleValueMap } from '../config';
+import { ManualGPUModeMap, ScheduleValueMap } from '../config';
 import { GPUListItem, ListItem } from '../config/types';
 
 type EmptyObject = Record<never, never>;
@@ -264,6 +264,7 @@ export default function useFormInitialValues() {
         provider: string;
         state: string;
         is_default: boolean;
+        gpu_instance_enabled?: boolean;
         owner_principal_id?: number;
       }
     >[]
@@ -277,7 +278,9 @@ export default function useFormInitialValues() {
         page: -1,
         // Exclude clusters that opt in to GPU-instance handling
         // (k8s_options.gpu_instance_options set) — those are for the
-        // GPU-service flow, not model deployment.
+        // GPU-service flow, not model deployment. A model-service cluster
+        // is the deploy target for both GPU sources: whole cards and the
+        // sliced GPUs its operator publishes as InstanceTypes.
         gpu_instance_enabled: false,
         // Only clusters owned by the current org. Drops cross-org grants
         // (e.g. the Default org's "shared with everyone" clusters) so a
@@ -286,7 +289,7 @@ export default function useFormInitialValues() {
         // the org picker (see basic.tsx).
         mine: true
       });
-      const list = response.items.map((item) => ({
+      const list = (response.items || []).map((item) => ({
         label: item.name,
         value: item.id,
         provider: item.provider as string,
@@ -344,12 +347,17 @@ export default function useFormInitialValues() {
    * @returns
    */
   const generateFormValues = (data: ListItem, gpuOptions: any[]) => {
+    // Either selector means the GPUs were picked by hand, so both hydrate the
+    // manual mode; which one was used selects its tab.
+    const isVGPU = !!data?.gpu_type_selector?.type;
     const formData = {
       ...data,
       categories: data?.categories?.length ? data.categories[0] : null,
-      scheduleType: data?.gpu_selector
-        ? ScheduleValueMap.Manual
-        : ScheduleValueMap.Auto
+      scheduleType:
+        isVGPU || data?.gpu_selector
+          ? ScheduleValueMap.Manual
+          : ScheduleValueMap.Auto,
+      manualGpuMode: isVGPU ? ManualGPUModeMap.VGPU : ManualGPUModeMap.FullGPU
     };
     return formData;
   };

--- a/src/pages/llmodels/hooks/use-gpu-type-display-name.ts
+++ b/src/pages/llmodels/hooks/use-gpu-type-display-name.ts
@@ -1,0 +1,71 @@
+import { queryGPUInstanceTypes } from '@/pages/gpu-service/instance-types/apis';
+import { atom, getDefaultStore, useAtomValue } from 'jotai';
+import { useEffect } from 'react';
+
+/**
+ * Display names of a cluster's GPU instance types, keyed by cluster id and
+ * then by the type's (cluster-scoped) name.
+ *
+ * A deployed model records only the type's name — the identifier the operator
+ * validates against — so every read-only view of a vGPU deployment (instance
+ * tooltip, instance list) has to resolve the human-readable name itself. It is
+ * resolved live rather than snapshotted at deploy time, because the display
+ * name is the one part of an instance type that stays editable.
+ */
+const displayNamesAtom = atom<Record<number, Record<string, string>>>({});
+
+// Clusters already fetched (or in flight), so N rows of the same cluster cost
+// one request. Not part of the atom: it is bookkeeping, not rendered state.
+const requested = new Set<number>();
+
+const fetchClusterTypes = async (clusterId: number) => {
+  if (requested.has(clusterId)) {
+    return;
+  }
+  requested.add(clusterId);
+  const store = getDefaultStore();
+  try {
+    const res = await queryGPUInstanceTypes({ cluster_id: clusterId });
+    const names = (res?.items || []).reduce(
+      (acc: Record<string, string>, item) => {
+        if (item.spec?.displayName) {
+          acc[item.name] = item.spec.displayName;
+        }
+        return acc;
+      },
+      {}
+    );
+    store.set(displayNamesAtom, {
+      ...store.get(displayNamesAtom),
+      [clusterId]: names
+    });
+  } catch {
+    // Leave the cluster unresolved; callers fall back to the type's name.
+    // Allow a retry on the next mount rather than caching the failure.
+    requested.delete(clusterId);
+  }
+};
+
+/**
+ * Resolve an instance type's display name, fetching the cluster's types once
+ * per session. Returns undefined until they land, and for a type that carries
+ * no display name or no longer exists — callers show the type's name instead.
+ */
+export const useGPUTypeDisplayName = (
+  clusterId?: number | null,
+  typeName?: string | null
+): string | undefined => {
+  const displayNames = useAtomValue(displayNamesAtom);
+
+  useEffect(() => {
+    if (clusterId == null || !typeName) {
+      return;
+    }
+    fetchClusterTypes(clusterId);
+  }, [clusterId, typeName]);
+
+  if (clusterId == null || !typeName) {
+    return undefined;
+  }
+  return displayNames[clusterId]?.[typeName];
+};

--- a/src/pages/llmodels/instance-view/use-instance-columns.tsx
+++ b/src/pages/llmodels/instance-view/use-instance-columns.tsx
@@ -3,7 +3,7 @@ import { tableSorter } from '@/config/settings';
 import { ListItem as workerListItem } from '@/pages/resources/config/types';
 import { usePluginListColumns } from '@/plugins/list-extra-columns';
 import { convertFileSize } from '@/utils';
-import { ThunderboltFilled } from '@ant-design/icons';
+import { PartitionOutlined, ThunderboltFilled } from '@ant-design/icons';
 import { AutoTooltip, IconFont } from '@gpustack/core-ui';
 import { useIntl } from '@umijs/max';
 import { ColumnsType } from 'antd/lib/table';
@@ -18,19 +18,39 @@ import NameCell, {
   NameCellProps
 } from '../components/instance-cells/name-cell';
 import {
+  formatGPUTypeAllocation,
+  getGPUTypeClusterId,
+  getGPUTypeSelector
+} from '../components/instance-cells/vgpu-info';
+import {
   DistributedServerItem,
   ModelInstanceListItem as ListItem,
   ListItem as ModelListItem
 } from '../config/types';
+import { useGPUTypeDisplayName } from '../hooks/use-gpu-type-display-name';
 import { calcTotalVram } from '../utils';
 
 const WorkerInfoContent: React.FC<
   NameCellProps & { workerList: workerListItem[] }
 > = ({ record, modelData, workerList }) => {
+  const intl = useIntl();
   let workerIp = '-';
   const distributed_servers = record.distributed_servers;
   const severList: DistributedServerItem[] =
     distributed_servers?.subordinate_workers || [];
+
+  // vGPU (InstanceType) allocation, e.g. "A10 (50% VRAM / 50% Compute)";
+  // empty for non-vGPU instances, which render exactly as before.
+  const gpuTypeSelector = getGPUTypeSelector(record, modelData);
+  const gpuTypeDisplayName = useGPUTypeDisplayName(
+    getGPUTypeClusterId(record, modelData),
+    gpuTypeSelector?.type
+  );
+  const vgpuAllocation = formatGPUTypeAllocation(
+    intl,
+    gpuTypeSelector,
+    gpuTypeDisplayName
+  );
 
   if (record.worker_ip) {
     workerIp = record.port
@@ -45,23 +65,38 @@ const WorkerInfoContent: React.FC<
         <DistributeInfoCell
           record={record}
           workerList={workerList}
+          gpuTypeSelector={getGPUTypeSelector(record, modelData)}
         ></DistributeInfoCell>
       ) : (
-        <div className="flex-center">
-          <IconFont
-            type="icon-filled-gpu"
-            className="m-r-5 text-quaternary"
-            style={{ fontSize: 12 }}
-          />
-          <span className="text-quaternary">
-            GPU:[
-            {_.join(
-              record.gpu_indexes?.sort?.((a, b) => a - b),
-              ','
-            )}
-            ]
-          </span>
-        </div>
+        <>
+          <div className="flex-center">
+            <IconFont
+              type="icon-filled-gpu"
+              className="m-r-5 text-quaternary"
+              style={{ fontSize: 12 }}
+            />
+            <span className="text-quaternary">
+              GPU:[
+              {_.join(
+                record.gpu_indexes?.sort?.((a, b) => a - b),
+                ','
+              )}
+              ]
+            </span>
+          </div>
+          {vgpuAllocation && (
+            <div className="flex-center">
+              <PartitionOutlined
+                className="m-r-5 text-quaternary"
+                style={{ fontSize: 12 }}
+              />
+              <span className="text-quaternary">
+                {intl.formatMessage({ id: 'models.table.vgpu' })}:{' '}
+                {vgpuAllocation}
+              </span>
+            </div>
+          )}
+        </>
       )}
     </div>
   );
@@ -86,15 +121,26 @@ const useInstancesColumns = (options: {
     options;
   const pluginCols = usePluginListColumns('modelInstances');
 
+  // Key the parent-model lookup once per render instead of a linear find
+  // per row (O(instances x models) on large lists).
+  const modelById = useMemo(
+    () => new Map(modelList.map((model) => [model.id, model])),
+    [modelList]
+  );
+
   const renderWorkerCell = (text: number, record: ListItem) => {
     if (text) {
+      // The instance payload does not echo gpu_type_selector; it lives on
+      // the parent model, already fetched into modelList.
+      const modelData = modelById.get(record.model_id);
       return (
         <WorkerInfoContent
           workerList={workerList}
           record={record}
           modelData={{
             backend: record.backend,
-            backend_version: record.backend_version
+            backend_version: record.backend_version,
+            gpu_type_selector: modelData?.gpu_type_selector
           }}
         ></WorkerInfoContent>
       );
@@ -214,11 +260,7 @@ const useInstancesColumns = (options: {
         render: (value: string, record: ListItem) => (
           <ActionsCell
             record={record}
-            modelData={
-              modelList.find(
-                (model) => model.id === record.model_id
-              ) as ModelListItem
-            }
+            modelData={modelById.get(record.model_id) as ModelListItem}
             onSelect={handleSelect}
           ></ActionsCell>
         )
@@ -229,7 +271,7 @@ const useInstancesColumns = (options: {
     onCellClick,
     workerList,
     clusterList,
-    modelList,
+    modelById,
     intl,
     pluginCols
   ]);

--- a/src/pages/llmodels/utils/index.ts
+++ b/src/pages/llmodels/utils/index.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import { ManualGPUModeMap, ScheduleValueMap } from '../config';
 import { FormData } from '../config/types';
 import { backendOptionsMap } from '../constants/backend-parameters';
 
@@ -35,16 +36,62 @@ export const generateGPUSelector = (data: any, gpuOptions: any[]) => {
 };
 
 /**
+ * build the gpu_type_selector payload field from the form values. Normalizes
+ * the four API keys: a partition profile zeroes the percentages, anything
+ * else nulls the profile, missing percentages become 0 (whole card).
+ * @param data
+ * @returns
+ */
+export const generateGPUTypeSelector = (data: FormData) => {
+  const selector = data.gpu_type_selector;
+
+  if (!selector?.type) {
+    return {
+      gpu_type_selector: null
+    };
+  }
+
+  const partitionedProfile = selector.accelerator_partitioned_profile || null;
+
+  return {
+    gpu_type_selector: {
+      type: selector.type,
+      accelerator_sliced_memory_percentage: partitionedProfile
+        ? 0
+        : _.toNumber(selector.accelerator_sliced_memory_percentage) || 0,
+      accelerator_sliced_cores_percentage: partitionedProfile
+        ? 0
+        : _.toNumber(selector.accelerator_sliced_cores_percentage) || 0,
+      accelerator_partitioned_profile: partitionedProfile
+    }
+  };
+};
+
+/**
  * before submit the form, generate the gpu_selector field, and clear worker_selector if needed
  * @param data
  * @returns
  */
 export const generateGPUIds = (data: FormData) => {
+  // The manual mode's vGPU tab: mutually exclusive with the whole-card
+  // gpu_selector — null it and emit gpu_type_selector instead.
+  if (
+    data.scheduleType === ScheduleValueMap.Manual &&
+    data.manualGpuMode === ManualGPUModeMap.VGPU
+  ) {
+    return {
+      gpu_selector: null,
+      worker_selector: null,
+      ...generateGPUTypeSelector(data)
+    };
+  }
+
   const gpu_ids = _.get(data, 'gpu_selector.gpu_ids', []);
 
   if (!gpu_ids.length) {
     return {
-      gpu_selector: null
+      gpu_selector: null,
+      gpu_type_selector: null
     };
   }
 
@@ -66,7 +113,8 @@ export const generateGPUIds = (data: FormData) => {
       gpu_ids: result || [],
       gpus_per_replica: data.gpu_selector?.gpus_per_replica || null
     },
-    worker_selector: null
+    worker_selector: null,
+    gpu_type_selector: null
   };
 };
 


### PR DESCRIPTION
## Summary

UI counterpart of the vGPU model-deployment feature (gpustack/gpustack#5192, backend PR gpustack/gpustack#5975).

Deploying two models onto one card gave them no isolation from each other. A deployment can now ask for a **slice** of a GPU instead of the whole card, by naming one of the InstanceType pools the cluster's gpustack-operator publishes.

### Where it lives

Picking GPUs by hand and asking a pool for a slice are two ways to do the same thing, so they sit side by side rather than as separate scheduling modes:

- **Scheduling Mode** stays `Auto | Manual`.
- Manual holds a bordered **GPU Allocation** section — mirroring Scheduled Scaling on the same form — whose `Full | Slicing` switch sits in the title row.
- **Full** keeps GPU Selector + GPUs per Replica. **Slicing** replaces them with GPU Type + the slice request.

The two GPU sources are mutually exclusive, so switching tabs seeds the one the tab owns and clears the other; the tab itself is form state (`manualGpuMode`) that never reaches the API.

### The slice request

`By Ratio` (VRAM / compute percentages) and `By Profile` (a hardware partition, e.g. MIG) appear only when the chosen type supports them — a type offering just one shows it directly with no switch, and the switch follows the cluster's live capability (toggling MIG on a node flips the type between the two).

Only accelerator types are listed: a cluster also publishes a CPU-only pool (`spec.acceleratable: false`), which cannot back a vGPU deployment.

**GPU Type** options carry what actually distinguishes one pool from another — its display name over vendor · memory · architecture. On the deployment list, an instance's tooltip resolves the type to that display name too (cached per cluster) rather than showing the raw CR name.

### Changed since the first round of review

- **vGPU is no longer its own Scheduling Mode.** It was a third entry in that dropdown; it is now the `Slicing` tab inside Manual, since it is a way of choosing GPUs manually, not a different scheduler.
- **The Instance Type field is renamed GPU Type**, and its options gained the vendor / memory / arch line.
- **The GPU Type preview card is gone** — the selected value plus the option line already carry it.
- **The cluster dropdown no longer filters by family.** The earlier filter (vGPU ⇒ GPU-service clusters only) came from a misreading: the deploy target is a **Model Service** cluster, which publishes InstanceTypes just the same. Reverted to the single-family fetch.
- **The instance tooltip shows the InstanceType's DisplayName** instead of its CR name.

## Test plan

- `npm run build` passes; `eslint src/pages/llmodels` reports 0 errors and 2 warnings, both pre-existing `react/no-unstable-nested-components` on the same render-prop pattern used elsewhere in the page; `tsc --noEmit` unchanged from the base.
- Manual E2E against a Nebius k8s cluster registered as **Model Service**, gpustack-operator v0.7.3, two H100 nodes (one MIG, one software-slicing), model `Qwen/Qwen3.5-0.8B` from ModelScope on vLLM 0.17.1:
  - Scheduling Mode dropdown now offers only Auto / Manual; Manual shows the GPU Allocation card with `Full | Slicing` on the right, Full showing GPU Selector + GPUs per Replica.
  - Slicing → **GPU Type** lists only `NVIDIA-H100-80GB-HBM3` (the CPU-only pool is filtered out), rendered as display name over `NVIDIA · 80 GB · amd64`. No preview card.
  - By Ratio 50% / 100% → instance RUNNING, inference OK. By Profile `1g.10gb` → instance RUNNING, inference OK.
  - Instance tooltip: `GPU Index: [0]`, `vGPU: NVIDIA-H100-80GB-HBM3 (50% VRAM / 100% Compute)`, `Allocated VRAM: 40 GiB` — the type shown is the DisplayName, not the CR name (`gpustack--nvidia-h100-80gb-hbm3-linux-amd64`).
  - Enabling MIG on both nodes and restarting the device-managers leaves only `By Profile`; disabling it leaves only `By Ratio`.
