### PR TITLE
fix(gpu-service): align partition availability with the operator ledger

### DIFF
--- a/src/pages/gpu-service/instance-types/config/types.ts
+++ b/src/pages/gpu-service/instance-types/config/types.ts
@@ -1,5 +1,6 @@
 import {
   InstanceTypeDetail,
+  InstanceTypePartitionedResource,
   InstanceTypeResource
 } from '../../instances/config/types';
 
@@ -30,7 +31,10 @@ export interface InstanceTypeStatus {
   accelerator?: InstanceTypeResource | null;
   acceleratorShared?: InstanceTypeResource | null;
   acceleratorSliced?: InstanceTypeResource | null;
-  acceleratorPartitioned?: InstanceTypeResource | null;
+  // Carries this cluster's per-profile partition ledger beside the scalars. The
+  // vGPU form reads remainingProfiles from here — this per-cluster shape, not the
+  // aggregated list-typed acceleratorPartitioned dimension.
+  acceleratorPartitioned?: InstanceTypePartitionedResource | null;
   cpu?: InstanceTypeResource | null;
 }
 

--- a/src/pages/gpu-service/instances/components/instance-type-item.tsx
+++ b/src/pages/gpu-service/instances/components/instance-type-item.tsx
@@ -8,10 +8,23 @@ import { manufactureColorMap } from '../../templates/config';
 import { formatManufacturer } from '../../utils';
 import { formatMemoryDisplay } from '../config';
 import {
+  AcceleratorProfileCount,
   InstanceTypeItem as InstanceTypeItemModel,
   InstanceTypeSnapshotSpec
 } from '../config/types';
 import { buildInstanceTypeSnapshotSpec } from '../utils/instance-description';
+
+// The card's partition figure: the largest number of instances of a single
+// profile the fleet can still build. max, not Σ — the profiles of one card
+// compete for the same physical slices, so summing them multiply-counts the same
+// hardware. A server older than the ledger sends this dimension as a scalar
+// quantity string rather than a list, so fall back to reading it as one.
+const maxObtainablePartitionCount = (
+  counts?: AcceleratorProfileCount[] | null
+): number =>
+  Array.isArray(counts)
+    ? counts.reduce((max, entry) => Math.max(max, entry?.count ?? 0), 0)
+    : Number(counts) || 0;
 
 const Title = styled.div`
   display: flex;
@@ -69,9 +82,13 @@ interface MetadataSectionProps {
   // status.onceMaxRequest.acceleratorSliced (max sliceable percentage). Shown
   // next to Max for sliceable types.
   slicedMaxPercentage?: number;
-  // status.onceMaxRequest.acceleratorPartitioned — how many hardware
-  // partitions the pool can still admit. A cross-node aggregate: it says the
-  // pool has room, not that any single node fits a given profile.
+  // The largest number of instances of a single partition profile the fleet can
+  // still build — max(count) over status.remaining.acceleratorPartitioned.
+  //
+  // Not from onceMaxRequest: on this dimension the API caps every entry at 1,
+  // because a partition request is always one instance on one card, so it
+  // carries no magnitude at all. A cross-node aggregate either way: it says the
+  // fleet has room somewhere, not that any single node fits a given profile.
   partitionedMax?: number;
 }
 
@@ -302,9 +319,9 @@ const InstanceTypeItem: React.FC<InstanceTypeItemProps> = ({
         slicedMaxPercentage={
           Number(item.status?.onceMaxRequest?.acceleratorSliced) || 0
         }
-        partitionedMax={
-          Number(item.status?.onceMaxRequest?.acceleratorPartitioned) || 0
-        }
+        partitionedMax={maxObtainablePartitionCount(
+          item.status?.remaining?.acceleratorPartitioned
+        )}
       ></InstanceMetadataSection>
     </Flex>
   );

--- a/src/pages/gpu-service/instances/components/instance-type-item.tsx
+++ b/src/pages/gpu-service/instances/components/instance-type-item.tsx
@@ -1,7 +1,7 @@
 import PluginExtraFields from '@/components/plugin-extra-fields';
 import { AutoTooltip, IconFont, ThemeTag } from '@gpustack/core-ui';
 import { useIntl } from '@umijs/max';
-import { Flex, Tag } from 'antd';
+import { Flex, Tag, Tooltip } from 'antd';
 import _ from 'lodash';
 import styled from 'styled-components';
 import { manufactureColorMap } from '../../templates/config';
@@ -25,6 +25,17 @@ const maxObtainablePartitionCount = (
   Array.isArray(counts)
     ? counts.reduce((max, entry) => Math.max(max, entry?.count ?? 0), 0)
     : Number(counts) || 0;
+
+// The breakdown behind that figure. Since it is a max, the number belongs to
+// exactly one profile and is unattributable on its own — the tooltip is what
+// says which. Entries at zero are dropped: those are profiles the pool offers
+// but currently has no room for, and a missing count is zero, not unknown.
+const obtainablePartitionCounts = (
+  counts?: AcceleratorProfileCount[] | null
+): AcceleratorProfileCount[] =>
+  Array.isArray(counts)
+    ? counts.filter((entry) => !!entry?.name && (entry?.count ?? 0) > 0)
+    : [];
 
 const Title = styled.div`
   display: flex;
@@ -90,6 +101,10 @@ interface MetadataSectionProps {
   // carries no magnitude at all. A cross-node aggregate either way: it says the
   // fleet has room somewhere, not that any single node fits a given profile.
   partitionedMax?: number;
+  // The same ledger the figure above is reduced from, kept whole so the cell can
+  // attribute it per profile in its tooltip. Absent on the readonly edit card,
+  // which renders a persisted snapshot and has no live ledger to show.
+  partitionProfileCounts?: AcceleratorProfileCount[] | null;
 }
 
 const MetaItem: React.FC<{
@@ -192,7 +207,8 @@ const renderMetaRow = (items: MetaEntry[], columns: number, rowKey: string) => {
 export const InstanceMetadataSection: React.FC<MetadataSectionProps> = ({
   spec,
   slicedMaxPercentage,
-  partitionedMax
+  partitionedMax,
+  partitionProfileCounts
 }) => {
   const intl = useIntl();
 
@@ -232,10 +248,37 @@ export const InstanceMetadataSection: React.FC<MetadataSectionProps> = ({
     label: intl.formatMessage({ id: 'common.max' }, { count: '' }),
     value: `${spec.maxComputeUnitCount || 0}`
   };
+  // The capabilities computed above have to reach the value, not merely decide
+  // whether the cell renders: `x 6` IS the figure this cell exists to show, and
+  // the ratio ceiling beside it likewise. The tooltip attributes the count to the
+  // profile it belongs to, which a max cannot say on its own. The dashed underline
+  // is the affordance that says a tooltip is there at all — same treatment as the
+  // device-index cell in resources/hooks/use-worker-columns.
+  const partitionBreakdown = obtainablePartitionCounts(partitionProfileCounts);
+  const slicedValue = slicedCapabilities.join(' ');
   const slicedItem: MetaEntry = {
     icon: 'icon-sliced',
     label: intl.formatMessage({ id: 'gpuservice.instance.sliceable' }),
-    value: ' '
+    value:
+      partitionBreakdown.length > 0 ? (
+        <Tooltip
+          title={partitionBreakdown
+            .map((entry) => `${entry.name} × ${entry.count}`)
+            .join(', ')}
+        >
+          <span
+            style={{
+              cursor: 'pointer',
+              paddingBottom: 2,
+              borderBottom: '1px dashed var(--ant-blue-6)'
+            }}
+          >
+            {slicedValue}
+          </span>
+        </Tooltip>
+      ) : (
+        slicedValue
+      )
   };
 
   // GPU: 3 items/row → 11 cols. CPU: 2 items/row → 7 cols.
@@ -322,6 +365,7 @@ const InstanceTypeItem: React.FC<InstanceTypeItemProps> = ({
         partitionedMax={maxObtainablePartitionCount(
           item.status?.remaining?.acceleratorPartitioned
         )}
+        partitionProfileCounts={item.status?.remaining?.acceleratorPartitioned}
       ></InstanceMetadataSection>
     </Flex>
   );

--- a/src/pages/gpu-service/instances/config/index.ts
+++ b/src/pages/gpu-service/instances/config/index.ts
@@ -32,10 +32,15 @@ export const isSliceableDetail = (detail?: AcceleratorSlicedDetail | null) =>
 // Hard-slice profiles this pool OFFERS, per the static capability catalog. The
 // counts are the catalog's ceiling, and by design they do not move as partitions
 // are carved and released — so this cannot answer "which profiles can I still
-// get". That is the ledger's job (obtainablePartitionProfiles below); this stays
-// as the fallback for a server that predates the ledger, and as the answer to
-// "does this pool offer hardware partitioning at all".
-export const getPartitionProfiles = (
+// get". That is the ledger's job (obtainablePartitionProfiles below).
+//
+// Deliberately NOT exported: its only remaining use is as the version-skew
+// fallback inside getSelectablePartitionProfiles*, and every form that used to
+// call it was offering profiles the pool could no longer build. Keeping it
+// module-private is what stops that from creeping back under an
+// availability-sounding name. For "does this pool offer hardware partitioning at
+// all", use isPhysicalSliceable.
+const getOfferedPartitionProfiles = (
   detail?: AcceleratorSlicedDetail | null
 ): AcceleratorSlicedPhysicalDetailProfile[] =>
   (detail?.physical?.profiles ?? []).filter(
@@ -76,7 +81,9 @@ const selectablePartitionProfiles = (
   capability: AcceleratorSlicedDetail | null | undefined
 ): string[] =>
   obtainablePartitionProfiles(ledger) ??
-  getPartitionProfiles(capability).map((profile) => profile.name as string);
+  getOfferedPartitionProfiles(capability).map(
+    (profile) => profile.name as string
+  );
 
 // Aggregated shape (GET /gpu-instance-types/aggregated): the ledger is the
 // list-typed acceleratorPartitioned dimension of an overview resource. Pass

--- a/src/pages/gpu-service/instances/config/index.ts
+++ b/src/pages/gpu-service/instances/config/index.ts
@@ -66,24 +66,37 @@ export const obtainablePartitionProfiles = (
         .map((entry) => entry.name as string)
     : null;
 
+// Profile names a form may offer: the live ledger when there is one, else the
+// capability catalog. The fallback is deliberately at LIST level, never per
+// element — an empty ledger means "offered, nothing left" and must stay empty,
+// while a missing ledger means "unknown" and falls back. Collapsing the two
+// (e.g. `ledger?.[0] ?? catalog[0]`) silently resurrects unbuildable profiles.
+const selectablePartitionProfiles = (
+  ledger: AcceleratorProfileCount[] | null | undefined,
+  capability: AcceleratorSlicedDetail | null | undefined
+): string[] =>
+  obtainablePartitionProfiles(ledger) ??
+  getPartitionProfiles(capability).map((profile) => profile.name as string);
+
 // Aggregated shape (GET /gpu-instance-types/aggregated): the ledger is the
 // list-typed acceleratorPartitioned dimension of an overview resource. Pass
-// status.remaining for the fleet inventory, or a tier's onceMaxRequest to ask
-// whether one more can be built.
-export const getObtainablePartitionProfilesFromOverview = (
-  overview?: InstanceTypeOverviewResource | null
-): string[] | null =>
-  obtainablePartitionProfiles(overview?.acceleratorPartitioned);
+// status.remaining for the fleet inventory.
+export const getSelectablePartitionProfilesFromOverview = (
+  overview?: InstanceTypeOverviewResource | null,
+  capability?: AcceleratorSlicedDetail | null
+): string[] =>
+  selectablePartitionProfiles(overview?.acceleratorPartitioned, capability);
 
 // Per-cluster shape (GET /gpu-instance-types?cluster_id): the same ledger, but
 // nested on the partitioned resource. The two envelopes share the key name
 // `acceleratorPartitioned`, so reading the wrong one yields undefined and
 // silently falls back to the capability catalog — i.e. the bug these helpers
 // exist to remove. Pick the adapter that matches the endpoint.
-export const getObtainablePartitionProfilesFromResource = (
-  partitioned?: InstanceTypePartitionedResource | null
-): string[] | null =>
-  obtainablePartitionProfiles(partitioned?.remainingProfiles);
+export const getSelectablePartitionProfilesFromResource = (
+  partitioned?: InstanceTypePartitionedResource | null,
+  capability?: AcceleratorSlicedDetail | null
+): string[] =>
+  selectablePartitionProfiles(partitioned?.remainingProfiles, capability);
 
 // A profile name encodes its VRAM after the dot — "1g.10gb" → 10 (GB).
 export const parseProfileMemoryGB = (name?: string | null): number | null => {
@@ -417,16 +430,14 @@ export const pickCandidateForAccelerator = <
     // the type-level view is a Σ across candidates, so a profile the type offers
     // may have nothing left in this particular cluster. Falls back to the
     // capability catalog only when the candidate published no ledger at all.
-    if (partitionedProfile) {
-      const obtainable =
-        obtainablePartitionProfiles(
-          c.acceleratorPartitioned?.remainingProfiles
-        ) ??
-        getPartitionProfiles(c.acceleratorSlicedDetail).map(
-          (profile) => profile.name as string
-        );
-      if (!obtainable.includes(partitionedProfile)) return false;
-    }
+    if (
+      partitionedProfile &&
+      !getSelectablePartitionProfilesFromResource(
+        c.acceleratorPartitioned,
+        c.acceleratorSlicedDetail
+      ).includes(partitionedProfile)
+    )
+      return false;
     return true;
   };
 

--- a/src/pages/gpu-service/instances/config/index.ts
+++ b/src/pages/gpu-service/instances/config/index.ts
@@ -406,8 +406,10 @@ export const pickCandidateForAccelerator = <
         onceMaxRequest: {
           accelerator?: string | null;
           acceleratorSliced?: string | null;
-          acceleratorPartitioned?: AcceleratorProfileCount[] | null;
         };
+        remaining?: {
+          acceleratorPartitioned?: AcceleratorProfileCount[] | null;
+        } | null;
         candidates?: C[] | null;
       }[]
     | undefined
@@ -460,14 +462,24 @@ export const pickCandidateForAccelerator = <
     // Sliced / partitioned modes request a fraction of a single card, so the
     // tier's whole-card accelerator count (0 for a slice-only type) can't gate
     // them; fit on the tier's sliced / partitioned capacity instead.
-    // A partition request is one instance on one card, and the API already caps
-    // the tier's onceMaxRequest ledger at 1 per profile — so a listed profile is
-    // exactly "one more of this can be built". Absent ledger (an older server)
-    // means we cannot tell at tier level, so we do not gate here and let the
-    // candidate check decide.
+    // A partition request is one instance on one card, so "can one more of this
+    // profile be built in this tier" is exactly "the tier's remaining ledger
+    // counts it above zero" — that ledger is the Σ over the tier's Active
+    // candidates, so a listed profile means some candidate here can serve it.
+    //
+    // NOT the tier's onceMaxRequest: that bundle is winner-takes-all, and because
+    // the tier key IS Accelerator.OnceMaxRequest every candidate in a tier ties on
+    // it, so the winner is simply the FIRST Active candidate. Its capped ledger
+    // describes one cluster, not the tier — and since a MIG-mode card is never a
+    // free whole card, every MIG pool in the fleet collapses into the
+    // accelerator-0 tier. Gating on it lets one fully-carved cluster veto profiles
+    // the fleet can still build, which the dropdown (reading the Σ) still offers.
+    //
+    // Absent ledger (an older server) means we cannot tell at tier level, so we do
+    // not gate here and let the candidate check decide.
     const partitionedFits = () => {
       const obtainable = obtainablePartitionProfiles(
-        tier.onceMaxRequest?.acceleratorPartitioned
+        tier.remaining?.acceleratorPartitioned
       );
       return obtainable === null || obtainable.includes(partitionedProfile!);
     };

--- a/src/pages/gpu-service/instances/config/index.ts
+++ b/src/pages/gpu-service/instances/config/index.ts
@@ -5,8 +5,11 @@ import _ from 'lodash';
 import React from 'react';
 import { parseQuantityToGi } from '../../utils';
 import {
+  AcceleratorProfileCount,
   AcceleratorSlicedDetail,
   AcceleratorSlicedPhysicalDetailProfile,
+  InstanceTypeOverviewResource,
+  InstanceTypePartitionedResource,
   ListItem
 } from '../config/types';
 
@@ -26,15 +29,61 @@ export const isPhysicalSliceable = (detail?: AcceleratorSlicedDetail | null) =>
 export const isSliceableDetail = (detail?: AcceleratorSlicedDetail | null) =>
   isLogicalSliceable(detail) || isPhysicalSliceable(detail);
 
-// Selectable hard-slice profiles: those the pool can still provide (count > 0).
-// The counts are cross-node totals, so a positive count only means the pool has
-// room somewhere — the operator still decides placement.
+// Hard-slice profiles this pool OFFERS, per the static capability catalog. The
+// counts are the catalog's ceiling, and by design they do not move as partitions
+// are carved and released — so this cannot answer "which profiles can I still
+// get". That is the ledger's job (obtainablePartitionProfiles below); this stays
+// as the fallback for a server that predates the ledger, and as the answer to
+// "does this pool offer hardware partitioning at all".
 export const getPartitionProfiles = (
   detail?: AcceleratorSlicedDetail | null
 ): AcceleratorSlicedPhysicalDetailProfile[] =>
   (detail?.physical?.profiles ?? []).filter(
     (profile) => !!profile?.name && (profile?.count ?? 0) > 0
   );
+
+// Obtainable profile names from a partition ledger, or null for "cannot tell".
+//
+// null is not []: an empty or all-zero list means the pool offers partitioning
+// but has nothing left right now, while null means no ledger was sent at all —
+// and the caller must then fall back rather than render an empty dropdown, which
+// would turn version skew into a partition-mode regression instead of a graceful
+// degrade.
+//
+// The Array.isArray guard is what makes that safe: a server older than the
+// ledger sends this dimension as a scalar quantity string, not as a missing
+// field, so `counts` can arrive as "1" despite the type. Treat anything that is
+// not a list as "cannot tell".
+//
+// A missing count is zero, not unknown: the API omits it at zero, so an entry
+// naming only a profile is that profile at zero.
+export const obtainablePartitionProfiles = (
+  counts?: AcceleratorProfileCount[] | null
+): string[] | null =>
+  Array.isArray(counts)
+    ? counts
+        .filter((entry) => !!entry?.name && (entry?.count ?? 0) > 0)
+        .map((entry) => entry.name as string)
+    : null;
+
+// Aggregated shape (GET /gpu-instance-types/aggregated): the ledger is the
+// list-typed acceleratorPartitioned dimension of an overview resource. Pass
+// status.remaining for the fleet inventory, or a tier's onceMaxRequest to ask
+// whether one more can be built.
+export const getObtainablePartitionProfilesFromOverview = (
+  overview?: InstanceTypeOverviewResource | null
+): string[] | null =>
+  obtainablePartitionProfiles(overview?.acceleratorPartitioned);
+
+// Per-cluster shape (GET /gpu-instance-types?cluster_id): the same ledger, but
+// nested on the partitioned resource. The two envelopes share the key name
+// `acceleratorPartitioned`, so reading the wrong one yields undefined and
+// silently falls back to the capability catalog — i.e. the bug these helpers
+// exist to remove. Pick the adapter that matches the endpoint.
+export const getObtainablePartitionProfilesFromResource = (
+  partitioned?: InstanceTypePartitionedResource | null
+): string[] | null =>
+  obtainablePartitionProfiles(partitioned?.remainingProfiles);
 
 // A profile name encodes its VRAM after the dot — "1g.10gb" → 10 (GB).
 export const parseProfileMemoryGB = (name?: string | null): number | null => {
@@ -328,6 +377,7 @@ export const pickCandidateForAccelerator = <
     phase?: string | null;
     cpu?: { remaining?: string | null } | null;
     acceleratorSliced?: { remaining?: string | null } | null;
+    acceleratorPartitioned?: InstanceTypePartitionedResource | null;
     acceleratorSlicedDetail?: AcceleratorSlicedDetail | null;
   }
 >(
@@ -336,7 +386,7 @@ export const pickCandidateForAccelerator = <
         onceMaxRequest: {
           accelerator?: string | null;
           acceleratorSliced?: string | null;
-          acceleratorPartitioned?: string | null;
+          acceleratorPartitioned?: AcceleratorProfileCount[] | null;
         };
         candidates?: C[] | null;
       }[]
@@ -363,16 +413,20 @@ export const pickCandidateForAccelerator = <
     if (!acceleratable && parseQuantity(c.cpu?.remaining) <= 0) return false;
     if (sliced && parseQuantity(c.acceleratorSliced?.remaining) <= 0)
       return false;
-    // Match the requested profile by name against this candidate's own
-    // profile list — the type-level list is a union across candidates, so a
-    // profile offered by the type may be exhausted (count 0) or absent here.
-    if (
-      partitionedProfile &&
-      !getPartitionProfiles(c.acceleratorSlicedDetail).some(
-        (profile) => profile.name === partitionedProfile
-      )
-    )
-      return false;
+    // Match the requested profile by name against this candidate's own ledger —
+    // the type-level view is a Σ across candidates, so a profile the type offers
+    // may have nothing left in this particular cluster. Falls back to the
+    // capability catalog only when the candidate published no ledger at all.
+    if (partitionedProfile) {
+      const obtainable =
+        obtainablePartitionProfiles(
+          c.acceleratorPartitioned?.remainingProfiles
+        ) ??
+        getPartitionProfiles(c.acceleratorSlicedDetail).map(
+          (profile) => profile.name as string
+        );
+      if (!obtainable.includes(partitionedProfile)) return false;
+    }
     return true;
   };
 
@@ -388,8 +442,19 @@ export const pickCandidateForAccelerator = <
     // Sliced / partitioned modes request a fraction of a single card, so the
     // tier's whole-card accelerator count (0 for a slice-only type) can't gate
     // them; fit on the tier's sliced / partitioned capacity instead.
+    // A partition request is one instance on one card, and the API already caps
+    // the tier's onceMaxRequest ledger at 1 per profile — so a listed profile is
+    // exactly "one more of this can be built". Absent ledger (an older server)
+    // means we cannot tell at tier level, so we do not gate here and let the
+    // candidate check decide.
+    const partitionedFits = () => {
+      const obtainable = obtainablePartitionProfiles(
+        tier.onceMaxRequest?.acceleratorPartitioned
+      );
+      return obtainable === null || obtainable.includes(partitionedProfile!);
+    };
     const fits = partitionedProfile
-      ? parseQuantity(tier.onceMaxRequest?.acceleratorPartitioned) > 0
+      ? partitionedFits()
       : sliced
         ? parseQuantity(tier.onceMaxRequest?.acceleratorSliced) > 0
         : acceleratable

--- a/src/pages/gpu-service/instances/config/types.ts
+++ b/src/pages/gpu-service/instances/config/types.ts
@@ -133,6 +133,28 @@ export interface InstanceTypeResource {
   capacity: string;
 }
 
+// One entry of a partition ledger: a profile name and a count of instances —
+// allocated (bound) or remaining (still buildable), per the field carrying it.
+// Deliberately not AcceleratorSlicedPhysicalDetailProfile, which belongs to the
+// static capability catalog and carries memoryMib a ledger entry never has.
+//
+// An absent count means zero, not unknown: the API omits it at zero, so an entry
+// naming only a profile is that profile at zero. Only the whole list being
+// absent means unknown — see obtainablePartitionProfiles.
+export interface AcceleratorProfileCount {
+  name?: string | null;
+  count?: number | null;
+}
+
+// Partitioned-mode resource: the scalars every mode shares, plus the pool's
+// per-profile ledger. remainingProfiles lists every profile the pool offers,
+// including at zero, so "offered but currently full" stays distinguishable from
+// "not offered at all"; allocatedProfiles omits a profile holding nothing.
+export interface InstanceTypePartitionedResource extends InstanceTypeResource {
+  allocatedProfiles?: AcceleratorProfileCount[] | null;
+  remainingProfiles?: AcceleratorProfileCount[] | null;
+}
+
 export interface InstanceTypeCandidate {
   cluster: string;
   name: string;
@@ -142,10 +164,12 @@ export interface InstanceTypeCandidate {
   acceleratorShared?: InstanceTypeResource | null;
   // Sliced-mode available resource.
   acceleratorSliced?: InstanceTypeResource | null;
-  // Partitioned-mode (hardware slicing) available resource. Pool-level: the
-  // values sum every partition-mode card behind this type across nodes, so
-  // they are a capacity hint only — never a per-node placement assertion.
-  acceleratorPartitioned?: InstanceTypeResource | null;
+  // Partitioned-mode (hardware slicing) available resource, plus this
+  // candidate's per-profile ledger. Pool-level: the values sum every
+  // partition-mode card behind this type across nodes, so they are a capacity
+  // hint only — never a per-node placement assertion. remainingProfiles is what
+  // answers "can this cluster still build profile X".
+  acceleratorPartitioned?: InstanceTypePartitionedResource | null;
   // This candidate's sliced (partitioning) capability.
   acceleratorSlicedDetail?: AcceleratorSlicedDetail | null;
   phase?: 'Active' | 'Inactive' | 'Draining' | null;
@@ -161,9 +185,16 @@ export interface InstanceTypeOverviewResource {
   accelerator?: `${number}` | null;
   acceleratorShared?: `${number}` | null;
   acceleratorSliced?: `${number}` | null;
-  // Partition (hardware slice) count the pool can still admit — a cross-node
-  // aggregate, not a per-node figure.
-  acceleratorPartitioned?: `${number}` | null;
+  // The one dimension that is a list rather than a number, because it has no
+  // honest scalar: the profiles of a single card compete for the same physical
+  // slices, so a total over them is not a capacity and a best case over them is
+  // not a total. Read per profile:
+  //   - in onceMaxRequest every entry is capped at 1 (a partition request is
+  //     always one instance on one card), so it answers "can one more be built",
+  //     never "how many";
+  //   - in remaining it is the Σ over Active members, i.e. the inventory.
+  // A profile the pool offers but cannot currently build stays listed at zero.
+  acceleratorPartitioned?: AcceleratorProfileCount[] | null;
   cpu?: QuanityCPU | null;
 }
 
@@ -211,10 +242,16 @@ export interface AcceleratorSlicedPhysicalDetailProfile {
   // Profile identifier (e.g. "1g.10gb") — the value submitted as
   // spec.resources.acceleratorPartitionedProfile.
   name?: string | null;
-  // Partition instances this profile can still provide across the whole pool
-  // (summed by name over every card), not a single card's count.
+  // The pool's STATIC capability ceiling for this profile: how many instances
+  // its cards could hold if nothing else were carved (summed by name over every
+  // card), not a single card's count and NOT an availability figure — by design
+  // it does not move as instances are carved and released. For "how many can I
+  // still get", read the partition ledger
+  // (acceleratorPartitioned.remainingProfiles, or the aggregated
+  // acceleratorPartitioned dimension).
   count?: number | null;
-  // The profile's VRAM in MiB.
+  // The profile's VRAM in MiB. Only the capability catalog carries this; a
+  // ledger entry never does, which is why the two types stay separate.
   memoryMib?: number | null;
 }
 

--- a/src/pages/gpu-service/instances/forms/index.tsx
+++ b/src/pages/gpu-service/instances/forms/index.tsx
@@ -37,7 +37,7 @@ import TemplateBasicForm, {
 } from '../../templates/forms/basic';
 import {
   getPartitionPercentage,
-  getPartitionProfiles,
+  getSelectablePartitionProfilesFromOverview,
   isLogicalSliceable,
   isPhysicalSliceable,
   pickCandidateForAccelerator,
@@ -569,12 +569,16 @@ const GPUServiceInstanceForm: React.FC<InstanceFormProps> = forwardRef(
       applySlicedResourceScaling(instanceType);
     };
 
-    // Seed the partitioned default: the first profile the pool can still
-    // provide. Returns the chosen profile (null when the type offers none).
+    // Seed the partitioned default: the first profile the fleet can still BUILD,
+    // from the live ledger. Reading the capability catalog here would pre-fill a
+    // profile the pool can no longer build — one the ledger-backed dropdown does
+    // not even list, so the form would open on a value the user cannot re-pick.
+    // Returns the chosen profile (null when nothing is obtainable).
     const applyPartitionedDefaults = (instanceType?: InstanceTypeItem) => {
-      const profile = getPartitionProfiles(
+      const profile = getSelectablePartitionProfilesFromOverview(
+        instanceType?.status?.remaining,
         instanceType?.status?.detail?.slicedDetail
-      )[0]?.name;
+      )[0];
       form.setFieldValue(
         ['spec', 'resources', 'acceleratorPartitionedProfile'],
         profile ?? undefined
@@ -642,7 +646,13 @@ const GPUServiceInstanceForm: React.FC<InstanceFormProps> = forwardRef(
       const wholeMax = instanceType.spec?.maxComputeUnitCount ?? 0;
       const slicedMax =
         _.toNumber(instanceType.status?.onceMaxRequest?.acceleratorSliced) || 0;
-      const partitionProfiles = getPartitionProfiles(slicedDetail);
+      // Obtainable, not merely offered: this decides whether to auto-enter
+      // partitioned mode and which profile to seed, so the capability catalog
+      // would switch the form into a mode that has nothing to hand out.
+      const partitionProfiles = getSelectablePartitionProfilesFromOverview(
+        instanceType.status?.remaining,
+        slicedDetail
+      );
 
       if (wholeMax < 1 && isLogicalSliceable(slicedDetail) && slicedMax > 0) {
         setSliceMode('sliced');
@@ -656,7 +666,7 @@ const GPUServiceInstanceForm: React.FC<InstanceFormProps> = forwardRef(
         isPhysicalSliceable(slicedDetail) &&
         partitionProfiles.length > 0
       ) {
-        const profile = partitionProfiles[0].name!;
+        const profile = partitionProfiles[0];
         setSliceMode('partitioned');
         form.setFieldValue(
           ['spec', 'resources', 'acceleratorPartitionedProfile'],

--- a/src/pages/gpu-service/instances/forms/instance-type.tsx
+++ b/src/pages/gpu-service/instances/forms/instance-type.tsx
@@ -13,7 +13,8 @@ import InstanceTypeItem, {
   InstanceMetadataSection
 } from '../components/instance-type-item';
 import {
-  getPartitionProfiles,
+  getSelectablePartitionProfilesFromOverview,
+  getSelectablePartitionProfilesFromResource,
   isLogicalSliceable,
   isPhysicalSliceable
 } from '../config';
@@ -201,24 +202,35 @@ const InstanceTypeFormItem: React.FC<InstanceTypeFormItemProps> = ({
   // no cores selector, and the memory selector reads as a plain "Percentage".
   const coresOvercommit = !!slicedDetail?.logical?.coresPercentageOvercommit;
 
-  // Hard-slice profiles the pool can still provide. Pool-level counts (summed
-  // across nodes) — a hint about what's on offer, not a placement guarantee.
-  const partitionProfiles = getPartitionProfiles(slicedDetail);
+  // Hard-slice profiles the fleet can still BUILD, from the live ledger the
+  // aggregated status.remaining carries — not from status.detail.slicedDetail,
+  // which is the static capability catalog and by design does not move as
+  // partitions are carved, so it keeps offering profiles that can no longer be
+  // built. Falls back to the catalog only when no ledger was sent (an older
+  // server): there, an empty list would read as "nothing available" rather than
+  // "unknown". Still pool-level counts summed across nodes — a hint about what
+  // is on offer, not a placement guarantee.
+  const partitionProfileNames = getSelectablePartitionProfilesFromOverview(
+    selectedInstanceType?.status?.remaining,
+    slicedDetail
+  );
 
-  // Whether some candidate of the selected type still offers this profile —
-  // the pool-level list can outlive the last candidate that can serve it.
+  // Whether some candidate of the selected type can still build this profile —
+  // the fleet-wide list is a Σ across candidates, so it can outlive the last
+  // candidate able to serve it.
   const profileHasCandidate = (name: string) =>
     (selectedInstanceType?.status?.tiers ?? []).some((tier) =>
       (tier.candidates ?? []).some((candidate) =>
-        getPartitionProfiles(candidate.acceleratorSlicedDetail).some(
-          (profile) => profile.name === name
-        )
+        getSelectablePartitionProfilesFromResource(
+          candidate.acceleratorPartitioned,
+          candidate.acceleratorSlicedDetail
+        ).includes(name)
       )
     );
 
-  const partitionOptions = partitionProfiles.map((profile) => ({
-    label: profile.name as string,
-    value: profile.name as string
+  const partitionOptions = partitionProfileNames.map((name) => ({
+    label: name,
+    value: name
   }));
 
   const modeSegmented = showModeSwitch ? (

--- a/src/pages/gpu-service/instances/forms/instance-type.tsx
+++ b/src/pages/gpu-service/instances/forms/instance-type.tsx
@@ -244,7 +244,15 @@ const InstanceTypeFormItem: React.FC<InstanceTypeFormItemProps> = ({
       options={[
         {
           label: intl.formatMessage({ id: 'gpuservice.instance.mode.whole' }),
-          value: 'whole'
+          value: 'whole',
+          // No free whole card left → same treatment as the two divided modes.
+          // Without this the mode stays selectable and lands the user on
+          // "GPU Count (Max 0)" with every count disabled, while the count
+          // control still renders 1 as checked — a selected value that cannot
+          // be requested. maxComputeUnitCount is the live figure the adapter
+          // derives from the tiers, not a static ceiling, so it reaches 0
+          // exactly when the fleet has no whole card to give.
+          disabled: maxComputeUnitCount <= 0
         },
         ...(supportsSliced
           ? [

--- a/src/pages/gpu-service/instances/services/use-query-instance-types.ts
+++ b/src/pages/gpu-service/instances/services/use-query-instance-types.ts
@@ -2,7 +2,11 @@ import { useQueryData } from '@gpustack/core-ui';
 import React from 'react';
 import { ceilMilliToCore, parseQuantityToGi } from '../../utils';
 import { queryGPUServiceInstanceTypes } from '../apis';
-import { getAcceleratorMax, isSliceableDetail } from '../config';
+import {
+  getAcceleratorMax,
+  isSliceableDetail,
+  obtainablePartitionProfiles
+} from '../config';
 import { InstanceTypeItem } from '../config/types';
 
 type InstanceType = InstanceTypeItem & {
@@ -45,8 +49,21 @@ export default function useQueryInstanceTypes() {
       const wholeMax = Number(item.status?.onceMaxRequest?.accelerator) || 0;
       const slicedMax =
         Number(item.status?.onceMaxRequest?.acceleratorSliced) || 0;
+      // The partition dimension is a per-profile list, not a number — one entry
+      // per profile the pool offers, its count capped at 1 by the API. So the
+      // count of obtainable profiles is what stands in for a magnitude here.
+      // Reading it as a number instead yields NaN → 0, which would take a
+      // MIG-only pool (whole-card 0, and sliced 0 because a MIG-mode card
+      // reports logical: {}) out of service entirely: the type would vanish from
+      // the form even though every profile is available. A server older than the
+      // ledger sends a scalar here, hence the null branch.
+      const partitionedProfiles = obtainablePartitionProfiles(
+        item.status?.onceMaxRequest?.acceleratorPartitioned
+      );
       const partitionedMax =
-        Number(item.status?.onceMaxRequest?.acceleratorPartitioned) || 0;
+        partitionedProfiles === null
+          ? Number(item.status?.onceMaxRequest?.acceleratorPartitioned) || 0
+          : partitionedProfiles.length;
       return {
         maxComputeUnitCount: max || 0,
         available: wholeMax > 0 || slicedMax > 0 || partitionedMax > 0

--- a/src/pages/gpu-service/instances/services/use-query-instance-types.ts
+++ b/src/pages/gpu-service/instances/services/use-query-instance-types.ts
@@ -43,26 +43,32 @@ export default function useQueryInstanceTypes() {
 
     // Sliceable types stay selectable as long as whole-card, sliced (soft) or
     // partitioned (hard) capacity remains; unavailable only when all three of
-    // status.onceMaxRequest .accelerator / .acceleratorSliced /
-    // .acceleratorPartitioned are 0.
+    // onceMaxRequest.accelerator / onceMaxRequest.acceleratorSliced /
+    // remaining.acceleratorPartitioned are 0.
     if (isSliceableDetail(item.status?.detail?.slicedDetail)) {
       const wholeMax = Number(item.status?.onceMaxRequest?.accelerator) || 0;
       const slicedMax =
         Number(item.status?.onceMaxRequest?.acceleratorSliced) || 0;
       // The partition dimension is a per-profile list, not a number — one entry
-      // per profile the pool offers, its count capped at 1 by the API. So the
-      // count of obtainable profiles is what stands in for a magnitude here.
-      // Reading it as a number instead yields NaN → 0, which would take a
-      // MIG-only pool (whole-card 0, and sliced 0 because a MIG-mode card
-      // reports logical: {}) out of service entirely: the type would vanish from
-      // the form even though every profile is available. A server older than the
-      // ledger sends a scalar here, hence the null branch.
+      // per profile the pool offers. So the count of obtainable profiles is what
+      // stands in for a magnitude here. Reading it as a number instead yields
+      // NaN → 0, which would take a MIG-only pool (whole-card 0, and sliced 0
+      // because a MIG-mode card reports logical: {}) out of service entirely: the
+      // type would vanish from the form even though every profile is available.
+      // A server older than the ledger sends a scalar here, hence the null branch.
+      //
+      // Read from remaining, not onceMaxRequest: the latter is the winner-takes-all
+      // bundle of one tier — itself one candidate's capped ledger — so a single
+      // fully-carved cluster would grey the type out while the rest of the fleet
+      // has room. remaining is the true Σ across Active candidates, and since a
+      // partition request is always one instance on one card, "Σ > 0 for some
+      // profile" is exactly "something here can still be requested".
       const partitionedProfiles = obtainablePartitionProfiles(
-        item.status?.onceMaxRequest?.acceleratorPartitioned
+        item.status?.remaining?.acceleratorPartitioned
       );
       const partitionedMax =
         partitionedProfiles === null
-          ? Number(item.status?.onceMaxRequest?.acceleratorPartitioned) || 0
+          ? Number(item.status?.remaining?.acceleratorPartitioned) || 0
           : partitionedProfiles.length;
       return {
         maxComputeUnitCount: max || 0,

--- a/src/pages/llmodels/forms/vgpu-type.tsx
+++ b/src/pages/llmodels/forms/vgpu-type.tsx
@@ -3,7 +3,7 @@ import { queryGPUInstanceTypes } from '@/pages/gpu-service/instance-types/apis';
 import { ListItem as InstanceTypeListItem } from '@/pages/gpu-service/instance-types/config/types';
 import {
   formatMemoryDisplay,
-  getPartitionProfiles,
+  getSelectablePartitionProfilesFromResource,
   isLogicalSliceable,
   isPhysicalSliceable
 } from '@/pages/gpu-service/instances/config';
@@ -158,13 +158,26 @@ const VGPUTypeForm: React.FC = () => {
   // selector is hidden (a hidden field mirrors the memory value).
   const coresOvercommit = !!slicedDetail?.logical?.coresPercentageOvercommit;
 
+  // Profiles this cluster can still BUILD, from its own per-profile ledger.
+  //
+  // The shape matters: this form queries /gpu-instance-types?cluster_id, so the
+  // ledger arrives nested on status.acceleratorPartitioned.remainingProfiles —
+  // not as the list-typed acceleratorPartitioned dimension the GPU Instance form
+  // gets from the aggregated endpoint. Both envelopes use that same key name, so
+  // reading the wrong one yields undefined and silently falls back below.
+  //
+  // slicedDetail is the static capability catalog: it keeps offering profiles the
+  // pool can no longer build, because by design it does not move as partitions
+  // are carved and released. It stays the fallback for a server older than the
+  // ledger, where an empty list would read as "nothing available" instead of
+  // "unknown".
   const partitionOptions = useMemo(
     () =>
-      getPartitionProfiles(slicedDetail).map((profile) => ({
-        label: profile.name as string,
-        value: profile.name as string
-      })),
-    [slicedDetail]
+      getSelectablePartitionProfilesFromResource(
+        selectedInstanceType?.status?.acceleratorPartitioned,
+        slicedDetail
+      ).map((name) => ({ label: name, value: name })),
+    [selectedInstanceType, slicedDetail]
   );
 
   const supportsSliced = isLogicalSliceable(slicedDetail);


### PR DESCRIPTION
## What

Aligns both vGPU forms with the partition ledger `gpustack-operator` v0.8.0 publishes, so a MIG profile is offered only when the fleet can actually build it.

**Related**
- gpustack/gpustack#5984 — the matching server-side alignment (operator pins to v0.8.0, the partition-ledger schema this PR consumes, and the `gpustack-runtime` bump). Should land together with this one.
- gpustack/runtime#15 — merged and released as `gpustack-runtime` `0.2.2.post7`; it stops the Kubernetes deployer granting privilege to plugin-allocated devices, which is what makes a divided-mode instance actually stay inside its slice.

## The contract, as the operator actually implements it

- `remaining` is a true Σ over candidates → tier → item. **`onceMaxRequest` is winner-takes-all**: a tier's key *is* `Status.Accelerator.OnceMaxRequest`, so every candidate in a tier ties on `Cmp` and the "winner" is simply the first Active candidate. Its `capProfileCountsAtOne` ledger describes **one cluster, not the tier** — so an availability gate must read `remaining`, never the winner's bundle.
- The partition dimension is a **list** at tier/item level. `onceMaxRequest` caps every entry at `min(count, 1)`; `remaining` sums by name and sorts by name.
- **A zero count is an omitted key** (Go `omitempty` on `int32`). Missing count = zero; missing **list** = unknown. So the version-skew fallback belongs at list level, never per element — and an older server sends this dimension as a scalar **string**, not a missing field, hence the `Array.isArray` guard.
- Two endpoints, same key name, incompatible shapes: GPU Instance create reads `/gpu-instance-types/aggregated` (list-typed overview dimension), model create reads `/gpu-instance-types?cluster_id` (nested `status.acceleratorPartitioned.remainingProfiles`). Hence two named adapters in `instances/config/index.ts`.

## Commits

| | |
| --- | --- |
| `c9677b10` | read partition availability from the ledger instead of the capability catalog |
| `d0a5cdbb` / `a3aab689` | offer only the profiles the fleet / the cluster can build (GPU Instance form, model form) |
| `cb38db45` | read the type card's partition figure from inventory |
| `1a52ab4c` | keep the capability catalog out of reach so it cannot be read back by mistake |
| `0e1be0fb` | **gate partitions on inventory, not the winner's bundle** — both gates were reading `onceMaxRequest`; `acceleratorPartitioned` is removed from that param type so the wrong field cannot come back |
| `3ecbe4e5` | render the type card's partition figure — the card figure was computed and then never reached the screen (the cell's value was a literal space, at HEAD and at base); adds a per-profile `name × count` tooltip |
| `b2fe48d5` | disable Full GPU when no whole card is left, so it matches By Ratio's behaviour at zero |

## Verified on hardware

Nebius mk8s, 8×H100 with MIG enabled on one card, against a `gpustack` build carrying the matching schema.

- Four-stage carve/release walk on the GPU Instance form: the dropdown narrows differentially as profiles are consumed and widens again on release.
- The **omitted-count-key** contract observed live twice — an exhausted profile arrives as `{"name":"4g.40gb"}` with no count, and a fully-carved card returns all six entries bare.
- Model form: `supportsPartitioned = isPhysicalSliceable && partitionOptions.length > 0` behaves correctly in both directions — with the MIG card fully allocated the By Ratio / By Profile switch collapses and By Ratio renders alone; freeing the card brings the switch and all six profiles back.
- Both divided modes deployed real vLLM instances (`Qwen3.5-0.8B`) and served inference.

## Known follow-ups (recorded, deliberately not in this PR)

- `profileHasCandidate` ignores phase (pre-existing, one line).
- The soft-ratio dimension has the identical winner-takes-all defect (pre-existing, untouched).
- By Ratio presets do not reflect remaining capacity; `1g.20gb` and `2g.20gb` are indistinguishable in the form.
- Per-profile availability counts are deliberately **not** surfaced in the dropdown — a profile at zero simply is not offered.
