### PR TITLE
chore: bump @gpustack/core-ui to v1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@ant-design/icons": "^6.1.0",
     "@ant-design/pro-components": "3.1.0-0",
     "@braintree/sanitize-url": "^7.1.1",
-    "@gpustack/core-ui": "^1.1.2",
+    "@gpustack/core-ui": "^1.1.3",
     "@huggingface/gguf": "^0.1.7",
     "@huggingface/hub": "^0.15.1",
     "@huggingface/tasks": "^0.11.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.2
       '@gpustack/core-ui':
-        specifier: ^1.1.2
-        version: 1.1.2(k4n3tv37j5dipz4shs57farbhu)
+        specifier: ^1.1.3
+        version: 1.1.3(k4n3tv37j5dipz4shs57farbhu)
       '@huggingface/gguf':
         specifier: ^0.1.7
         version: 0.1.18
@@ -1432,8 +1432,8 @@ packages:
     resolution: {integrity: sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ==, tarball: https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz}
     deprecated: the package is rather renamed to @formatjs/ecma-abstract with some changes in functionality (primarily selectUnit is removed and we don't plan to make any further changes to this package
 
-  '@gpustack/core-ui@1.1.2':
-    resolution: {integrity: sha512-x9X05dWvdjBe5hTliWULoVYOboWheUhlICQQERIaPWoSPPdnPZyxXmXXtoo9RBxNNqDUvmvGytxR9syeKcBg+g==, tarball: https://registry.npmjs.org/@gpustack/core-ui/-/core-ui-1.1.2.tgz}
+  '@gpustack/core-ui@1.1.3':
+    resolution: {integrity: sha512-QvmiOH/u8lX43klF2F+MneG+mBcvx+PdKw0dfeh7j7GJvm/q+myvPwurVDMOYRHHpM6a1RoBS1JScE1yOFxiuw==, tarball: https://registry.npmjs.org/@gpustack/core-ui/-/core-ui-1.1.3.tgz}
     peerDependencies:
       '@ant-design/icons': ^6.1.0
       '@ant-design/pro-components': 3.1.0-0
@@ -10393,7 +10393,7 @@ snapshots:
 
   '@formatjs/intl-utils@2.3.0': {}
 
-  '@gpustack/core-ui@1.1.2(k4n3tv37j5dipz4shs57farbhu)':
+  '@gpustack/core-ui@1.1.3(k4n3tv37j5dipz4shs57farbhu)':
     dependencies:
       '@ant-design/icons': 6.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@ant-design/pro-components': 3.1.0-0(antd@6.3.7(date-fns@2.30.0)(luxon@3.7.2)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
Automated bump from [@gpustack/core-ui v1.1.3](https://github.com/gpustack/core-ui/releases/tag/v1.1.3).