### PR TITLE
feat(gpu-service): accessParams Connect links and template YAML editor

### DIFF
--- a/src/locales/en-US/gpuservice.ts
+++ b/src/locales/en-US/gpuservice.ts
@@ -3,6 +3,10 @@ export default {
   'gpuservice.template.add': 'Add Instance Template',
   'gpuservice.template.edit': 'Edit Instance Template',
   'gpuservice.template.clone': 'Clone Instance Template',
+  'gpuservice.template.editYaml': 'Edit YAML',
+  'gpuservice.template.editYaml.title': 'Edit Template YAML',
+  'gpuservice.template.editYaml.invalidSpec':
+    'Invalid YAML: a top-level "spec" object is required.',
   'gpuservice.template.filter.name': 'Filter by name',
   'gpuservice.template.filter.vendor': 'Filter by vendor',
   'gpuservice.template.image': 'Image',

--- a/src/locales/ja-JP/gpuservice.ts
+++ b/src/locales/ja-JP/gpuservice.ts
@@ -3,6 +3,10 @@ export default {
   'gpuservice.template.add': 'インスタンステンプレートを追加',
   'gpuservice.template.edit': 'インスタンステンプレートを編集',
   'gpuservice.template.clone': 'インスタンステンプレートを複製',
+  'gpuservice.template.editYaml': 'YAML を編集',
+  'gpuservice.template.editYaml.title': 'テンプレート YAML を編集',
+  'gpuservice.template.editYaml.invalidSpec':
+    'YAML が無効です：トップレベルの "spec" オブジェクトが必要です。',
   'gpuservice.template.filter.name': '名前でフィルター',
   'gpuservice.template.filter.vendor': 'ベンダーでフィルター',
   'gpuservice.template.image': 'コンテナイメージ',

--- a/src/locales/ru-RU/gpuservice.ts
+++ b/src/locales/ru-RU/gpuservice.ts
@@ -3,6 +3,10 @@ export default {
   'gpuservice.template.add': 'Добавить шаблон экземпляра',
   'gpuservice.template.edit': 'Редактировать шаблон экземпляра',
   'gpuservice.template.clone': 'Клонировать шаблон экземпляра',
+  'gpuservice.template.editYaml': 'Редактировать YAML',
+  'gpuservice.template.editYaml.title': 'Редактировать YAML шаблона',
+  'gpuservice.template.editYaml.invalidSpec':
+    'Недопустимый YAML: требуется объект "spec" верхнего уровня.',
   'gpuservice.template.filter.name': 'Фильтр по имени',
   'gpuservice.template.filter.vendor': 'Фильтр по производителю',
   'gpuservice.template.image': 'Образ',

--- a/src/locales/tr-TR/gpuservice.ts
+++ b/src/locales/tr-TR/gpuservice.ts
@@ -3,6 +3,10 @@ export default {
   'gpuservice.template.add': 'Örnek Şablonu Ekle',
   'gpuservice.template.edit': 'Örnek Şablonunu Düzenle',
   'gpuservice.template.clone': 'Örnek Şablonunu Klonla',
+  'gpuservice.template.editYaml': 'YAML Düzenle',
+  'gpuservice.template.editYaml.title': 'Şablon YAML Düzenle',
+  'gpuservice.template.editYaml.invalidSpec':
+    'Geçersiz YAML: üst düzey bir "spec" nesnesi gerekli.',
   'gpuservice.template.filter.name': 'Ada göre filtrele',
   'gpuservice.template.filter.vendor': 'Tedarikçiye göre filtrele',
   'gpuservice.template.image': 'İmaj',

--- a/src/locales/zh-CN/gpuservice.ts
+++ b/src/locales/zh-CN/gpuservice.ts
@@ -3,6 +3,10 @@ export default {
   'gpuservice.template.add': '添加实例模板',
   'gpuservice.template.edit': '编辑实例模板',
   'gpuservice.template.clone': '克隆实例模板',
+  'gpuservice.template.editYaml': '编辑 YAML',
+  'gpuservice.template.editYaml.title': '编辑模板 YAML',
+  'gpuservice.template.editYaml.invalidSpec':
+    'YAML 无效：缺少顶层 "spec" 对象。',
   'gpuservice.template.filter.name': '按名称过滤',
   'gpuservice.template.filter.vendor': '按厂商过滤',
   'gpuservice.template.image': '镜像',

--- a/src/pages/gpu-service/instances/config/types.ts
+++ b/src/pages/gpu-service/instances/config/types.ts
@@ -34,6 +34,7 @@ export interface FormData {
       port: number;
       protocol?: string;
       name?: string;
+      accessParams?: Record<string, string>;
     }[];
     env: {
       name: string;

--- a/src/pages/gpu-service/instances/hooks/use-instances-columns.tsx
+++ b/src/pages/gpu-service/instances/hooks/use-instances-columns.tsx
@@ -63,24 +63,31 @@ const getConnectEntries = (record: ListItem): ConnectEntry[] => {
       const isSsh =
         (p.protocol === 'TCP' && p.port === 22) ||
         _.includes(_.toLower(p.name), 'ssh');
-      return isSsh
-        ? {
-            type: 'ssh',
-            name: 'SSH',
-            key: `ssh-${p.nodePort}`,
-            protocol: _.toUpper(p.protocol),
-            command: `ssh root@${ip} -p ${p.nodePort}`
-          }
-        : {
-            type: 'http',
-            name:
-              configPorts.find((port) => port.port === p.port)?.name ||
-              _.toUpper(p.protocol),
-            key: `http-${p.nodePort}`,
-            port: p.port,
-            protocol: _.toUpper(p.protocol),
-            url: `http://${ip}:${p.nodePort}`
-          };
+      if (isSsh) {
+        return {
+          type: 'ssh',
+          name: 'SSH',
+          key: `ssh-${p.nodePort}`,
+          protocol: _.toUpper(p.protocol),
+          command: `ssh root@${ip} -p ${p.nodePort}`
+        };
+      }
+      const configPort = configPorts.find((port) => port.port === p.port);
+      // accessParams is generic query-param metadata from the spec (e.g. a
+      // Jupyter token): serialize whatever keys it carries onto the URL.
+      const accessParams = configPort?.accessParams;
+      const query =
+        _.isPlainObject(accessParams) && !_.isEmpty(accessParams)
+          ? `?${new URLSearchParams(accessParams).toString()}`
+          : '';
+      return {
+        type: 'http',
+        name: configPort?.name || _.toUpper(p.protocol),
+        key: `http-${p.nodePort}`,
+        port: p.port,
+        protocol: _.toUpper(p.protocol),
+        url: `http://${ip}:${p.nodePort}${query}`
+      };
     });
 };
 

--- a/src/pages/gpu-service/templates/components/edit-yaml-modal.tsx
+++ b/src/pages/gpu-service/templates/components/edit-yaml-modal.tsx
@@ -1,0 +1,129 @@
+import useUserSettings from '@/hooks/use-user-settings';
+import { json2Yaml, yaml2Json } from '@/pages/backends/config';
+import { ModalFooter, useSubmitLock } from '@gpustack/core-ui';
+import { YamlEditor } from '@gpustack/core-ui/yaml-editor';
+import { useIntl } from '@umijs/max';
+import { Modal } from 'antd';
+import _ from 'lodash';
+import { useEffect, useRef, useState } from 'react';
+import { FormData, ListItem } from '../config/types';
+
+// Fields the update endpoint owns: identity and audit columns (id,
+// owner_principal_id, creator_id, timestamps) are server-managed, so the
+// YAML carries exactly what a PUT may change.
+const YAML_FIELDS = [
+  'name',
+  'displayName',
+  'description',
+  'manufacturer',
+  'spec'
+];
+
+// Drop null-valued keys (recursively) so the editor opens with meaningful
+// content only; unset fields stay absent rather than reading as explicit
+// nulls.
+const stripNulls = (value: any): any => {
+  if (_.isArray(value)) {
+    return value.map(stripNulls);
+  }
+  if (_.isPlainObject(value)) {
+    return _.mapValues(_.omitBy(value, _.isNull), stripNulls);
+  }
+  return value;
+};
+
+type EditYamlModalProps = {
+  open: boolean;
+  currentData: ListItem;
+  onOk: (id: number, values: FormData) => Promise<void> | void;
+  onCancel: () => void;
+};
+
+const EditYamlModal: React.FC<EditYamlModalProps> = ({
+  open,
+  currentData,
+  onOk,
+  onCancel
+}) => {
+  const intl = useIntl();
+  const { isDarkTheme } = useUserSettings();
+  const editorRef = useRef<any>(null);
+  // ``run`` (not ``guard``): guard's lock is only released by a nested run,
+  // so a parse failure inside guard would wedge every later Save click.
+  const { loading, run } = useSubmitLock();
+  const [error, setError] = useState('');
+
+  const content = json2Yaml(stripNulls(_.pick(currentData, YAML_FIELDS)));
+
+  // The core-ui YamlEditor creates its monaco model under a fixed path, so a
+  // remount reuses the previous model instead of the new `value` prop — push
+  // the intended content imperatively once the editor is up (it initializes
+  // asynchronously, hence the short retry loop).
+  useEffect(() => {
+    let retries = 0;
+    const timer = setInterval(() => {
+      if (editorRef.current?.setValue) {
+        editorRef.current.setValue(content);
+        clearInterval(timer);
+      } else if (++retries >= 40) {
+        clearInterval(timer);
+      }
+    }, 50);
+    return () => clearInterval(timer);
+  }, []);
+
+  const handleOk = () =>
+    run(async () => {
+      try {
+        const parsed = yaml2Json(editorRef.current?.getValue() ?? '');
+        if (
+          !_.isPlainObject(parsed) ||
+          !_.isPlainObject((parsed as any).spec)
+        ) {
+          throw new Error(
+            intl.formatMessage({
+              id: 'gpuservice.template.editYaml.invalidSpec'
+            })
+          );
+        }
+        setError('');
+        // Keep the payload inside the PUT-mutable shape: anything else the
+        // user typed (id, audit fields) is dropped client-side.
+        await onOk(currentData.id, _.pick(parsed, YAML_FIELDS) as FormData);
+      } catch (e) {
+        setError((e as Error).message);
+      }
+    });
+
+  return (
+    <Modal
+      title={intl.formatMessage({ id: 'gpuservice.template.editYaml.title' })}
+      open={open}
+      onCancel={onCancel}
+      width={720}
+      maskClosable={false}
+      footer={
+        <ModalFooter
+          onOk={handleOk}
+          onCancel={onCancel}
+          loading={loading}
+          style={{
+            padding: '16px 0 8px',
+            display: 'flex',
+            justifyContent: 'flex-end'
+          }}
+        />
+      }
+    >
+      <YamlEditor
+        ref={editorRef}
+        value={content}
+        height="calc(100vh - 320px)"
+        validateMessage={error}
+        isDarkTheme={isDarkTheme}
+      />
+    </Modal>
+  );
+};
+
+export default EditYamlModal;

--- a/src/pages/gpu-service/templates/config/index.tsx
+++ b/src/pages/gpu-service/templates/config/index.tsx
@@ -115,6 +115,12 @@ export const templateActions: Array<{
     icon: icons.EditOutlined
   },
   {
+    label: 'gpuservice.template.editYaml',
+    key: 'editYaml',
+    locale: true,
+    icon: icons.FileTextOutlined
+  },
+  {
     label: 'common.button.clone',
     key: 'clone',
     locale: true,

--- a/src/pages/gpu-service/templates/config/types.ts
+++ b/src/pages/gpu-service/templates/config/types.ts
@@ -2,6 +2,7 @@ export interface PortItem {
   protocol: 'UDP' | 'TCP';
   port: number;
   name?: string;
+  accessParams?: Record<string, string>;
 }
 
 export type ImagePullPolicy = 'Always' | 'IfNotPresent' | 'Never';

--- a/src/pages/gpu-service/templates/index.tsx
+++ b/src/pages/gpu-service/templates/index.tsx
@@ -10,7 +10,7 @@ import {
 import { useIntl } from '@umijs/max';
 import { useMemoizedFn } from 'ahooks';
 import _ from 'lodash';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import PageBox from '../../_components/page-box';
 import { GPUsConfigs } from '../../resources/config/gpu-driver';
 import {
@@ -21,6 +21,7 @@ import {
   updateGPUServiceTemplate
 } from './apis';
 import AddModal from './components/add-modal';
+import EditYamlModal from './components/edit-yaml-modal';
 import TemplateCardList from './components/template-list';
 import { FormData, ListItem } from './config/types';
 import useCreateTemplate from './hooks/use-create-template';
@@ -54,6 +55,10 @@ const GPUServiceTemplates: React.FC = () => {
   });
   const { openTemplateModalStatus, openTemplateModal, closeTemplateModal } =
     useCreateTemplate();
+  const [yamlEdit, setYamlEdit] = useState<{
+    open: boolean;
+    data: ListItem | null;
+  }>({ open: false, data: null });
 
   const manufacturerOptions = useMemo(
     () => [
@@ -148,6 +153,10 @@ const GPUServiceTemplates: React.FC = () => {
       handleEditTemplate(item.data);
       return;
     }
+    if (item.action === 'editYaml') {
+      setYamlEdit({ open: true, data: item.data });
+      return;
+    }
     if (item.action === 'clone') {
       handleCloneTemplate(item.data);
       return;
@@ -155,6 +164,17 @@ const GPUServiceTemplates: React.FC = () => {
     if (item.action === 'delete') {
       handleDelete({ ...item.data, name: item.data.name });
     }
+  };
+
+  const closeYamlEdit = () => setYamlEdit({ open: false, data: null });
+
+  const handleYamlOk = async (id: number, data: FormData) => {
+    await updateGPUServiceTemplate({
+      id,
+      data
+    });
+    closeYamlEdit();
+    handleSearch();
   };
 
   const loadMore = useMemoizedFn((nextPage: number) => {
@@ -237,6 +257,14 @@ const GPUServiceTemplates: React.FC = () => {
         onCancel={closeTemplateModal}
         onOk={handleModalOk}
       />
+      {yamlEdit.open && yamlEdit.data && (
+        <EditYamlModal
+          open={yamlEdit.open}
+          currentData={yamlEdit.data}
+          onOk={handleYamlOk}
+          onCancel={closeYamlEdit}
+        />
+      )}
       <DeleteModal ref={modalRef} />
     </PageBox>
   );


### PR DESCRIPTION
## Summary

UI counterpart of gpustack/gpustack#6036 (for gpustack/gpustack#5757).

- **Connect links carry `accessParams`**: the GPU instance list's Connect column serializes the spec port's `accessParams` onto the web access URL (`http://<ip>:<nodePort>?token=<token>` for the secured JupyterLab templates). Fully generic via `URLSearchParams` — any future key works without UI changes. Ports without `accessParams` and SSH entries render unchanged.
- **YAML editor for instance templates**: template cards gain an "Edit YAML" action (en/zh/ja/ru/tr) opening a modal with the core-ui `YamlEditor`, so admins can edit fields the form doesn't expose — `command` and `ports[].accessParams`. This is the remediation path for existing installs whose stored templates predate the backend's secured built-ins: edit the template YAML, replace `--ServerApp.token='' --ServerApp.password=''` with `--ServerApp.token={{generated_token}}`, add `accessParams`.

Implementation notes:

- YAML dumps only PUT-mutable fields, with null-valued keys stripped.
- The modal force-sets content on mount: the core-ui YamlEditor creates its monaco model under a fixed path, so a remount would otherwise reuse stale content.
- Submit uses `run()` rather than `guard()` — guard's lock is only released by a nested run, so a parse failure would wedge all later Save clicks.

## Test plan

- Verified against a live backend on a k3s cluster: Connect link for a token-carrying instance is `http://<ip>:<nodePort>?token=<token>` and logs straight into JupyterLab; instances without `accessParams` unchanged.
- YAML editor: opens with clean content (nulls stripped), reopen resets content, invalid YAML shows an error and does not submit, a real edit round-trips through PUT and is reflected by the API.

## Related

- Backend: gpustack/gpustack#6036