### PR TITLE
chore: bump @gpustack/core-ui to v1.1.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@ant-design/icons": "^6.1.0",
     "@ant-design/pro-components": "3.1.0-0",
     "@braintree/sanitize-url": "^7.1.1",
-    "@gpustack/core-ui": "^1.1.6",
+    "@gpustack/core-ui": "^1.1.7",
     "@huggingface/gguf": "^0.1.7",
     "@huggingface/hub": "^0.15.1",
     "@huggingface/tasks": "^0.11.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ importers:
         specifier: ^7.1.1
         version: 7.1.2
       '@gpustack/core-ui':
-        specifier: ^1.1.6
-        version: 1.1.6(k4n3tv37j5dipz4shs57farbhu)
+        specifier: ^1.1.7
+        version: 1.1.7(k4n3tv37j5dipz4shs57farbhu)
       '@huggingface/gguf':
         specifier: ^0.1.7
         version: 0.1.18
@@ -1432,8 +1432,8 @@ packages:
     resolution: {integrity: sha512-KWk80UPIzPmUg+P0rKh6TqspRw0G6eux1PuJr+zz47ftMaZ9QDwbGzHZbtzWkl5hgayM/qrKRutllRC7D/vVXQ==, tarball: https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.3.0.tgz}
     deprecated: the package is rather renamed to @formatjs/ecma-abstract with some changes in functionality (primarily selectUnit is removed and we don't plan to make any further changes to this package
 
-  '@gpustack/core-ui@1.1.6':
-    resolution: {integrity: sha512-WB4et/OVqObEkX/sPEb2y5wou0XwdxAJKIx8ayzhm1jt1O/Hk5yQI/Xt7QUQBjzGpnanFNjXYA8OMXmDCi+USQ==, tarball: https://registry.npmjs.org/@gpustack/core-ui/-/core-ui-1.1.6.tgz}
+  '@gpustack/core-ui@1.1.7':
+    resolution: {integrity: sha512-wClIY02JLmZ0kgwLEpQO3SlTKnBvMjomI6OQVNSt2+Fruun5AlGex9DDIwMat3pUX65Y7sn0YnIr0+P/oBH7eQ==, tarball: https://registry.npmjs.org/@gpustack/core-ui/-/core-ui-1.1.7.tgz}
     peerDependencies:
       '@ant-design/icons': ^6.1.0
       '@ant-design/pro-components': 3.1.0-0
@@ -5804,8 +5804,8 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==, tarball: https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz}
 
-  mammoth@1.12.0:
-    resolution: {integrity: sha512-cwnK1RIcRdDMi2HRx2EXGYlxqIEh0Oo3bLhorgnsVJi2UkbX1+jKxuBNR9PC5+JaX7EkmJxFPmo6mjLpqShI2w==, tarball: https://registry.npmjs.org/mammoth/-/mammoth-1.12.0.tgz}
+  mammoth@1.12.1:
+    resolution: {integrity: sha512-nCH9KKjWi3jQ+i8bUKs7k1yrXtSEGpWgF8IYkzsFMcbn+5S6l4bZEBbyx2hOQErFiXPuAs9RPa6qjXVxhyx/8g==, tarball: https://registry.npmjs.org/mammoth/-/mammoth-1.12.1.tgz}
     engines: {node: '>=12.0.0'}
     hasBin: true
 
@@ -10394,7 +10394,7 @@ snapshots:
 
   '@formatjs/intl-utils@2.3.0': {}
 
-  '@gpustack/core-ui@1.1.6(k4n3tv37j5dipz4shs57farbhu)':
+  '@gpustack/core-ui@1.1.7(k4n3tv37j5dipz4shs57farbhu)':
     dependencies:
       '@ant-design/icons': 6.2.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@ant-design/pro-components': 3.1.0-0(antd@6.3.7(date-fns@2.30.0)(luxon@3.7.2)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10417,7 +10417,7 @@ snapshots:
       katex: 0.16.45
       lamejs: https://codeload.github.com/zhuker/lamejs/tar.gz/582bbba6a12f981b984d8fb9e1874499fed85675
       lodash: 4.18.1
-      mammoth: 1.12.0
+      mammoth: 1.12.1
       marked: 14.1.4
       monaco-editor: 0.30.1
       monaco-yaml: 4.0.4(monaco-editor@0.30.1)
@@ -16127,7 +16127,7 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
-  mammoth@1.12.0:
+  mammoth@1.12.1:
     dependencies:
       '@xmldom/xmldom': 0.8.13
       argparse: 1.0.10


### PR DESCRIPTION
Automated bump from [@gpustack/core-ui v1.1.7](https://github.com/gpustack/core-ui/releases/tag/v1.1.7).