### PR TITLE
feat(gpu-service): filter by cluster purpose and configure all operator settings

### DIFF
--- a/src/locales/en-US/clusters.ts
+++ b/src/locales/en-US/clusters.ts
@@ -198,5 +198,15 @@ export default {
     'For on-demand GPU compute — e.g. interactive development, training jobs, or custom environments.',
   'clusters.gpuInstances.staticAddress': 'GPU Service Static Access Address',
   'clusters.gpuInstances.staticAddress.tip':
-    'Static address the operator uses to access GPU instances in this cluster (e.g. a LoadBalancer VIP). Optional.'
+    'Static address the operator uses to access GPU instances in this cluster (e.g. a LoadBalancer VIP). Operator default: empty — the access address is generated from host IPs. Changing it does not re-address GPU instances that are already deployed; it applies to newly created ones.',
+  'clusters.gpuInstances.derivedFromNode': 'Derive Instance Types from Nodes',
+  'clusters.gpuInstances.derivedFromNode.tip':
+    'Whether the operator auto-derives instance types (and their backing queues) from node hardware. Enabled: the operator authors a derived instance type for each node flavor. Disabled: it only aligns the resource flavor, and you define every instance type yourself. Operator default: Enabled.',
+  'clusters.gpuInstances.mixedOnNode': 'Allow Mixed Instance Types on a Node',
+  'clusters.gpuInstances.mixedOnNode.tip':
+    'Whether one node may serve both an accelerated and a CPU-only instance type. Enabled: a node is summarized into every type it can serve. Disabled: a node with accelerators yields only an accelerated type, and a CPU-only node only a general one. Operator default: Enabled.',
+  'clusters.gpuInstances.setting.enabled': 'Enabled',
+  'clusters.gpuInstances.setting.disabled': 'Disabled',
+  'clusters.gpuInstances.setting.unmanaged':
+    'Unmanaged (the cluster keeps its own value)'
 };

--- a/src/locales/en-US/no-result.ts
+++ b/src/locales/en-US/no-result.ts
@@ -37,7 +37,7 @@ export default {
   'noresult.resources.cluster':
     'No clusters available. Add a cluster to get started.',
   'noresult.resources.k8sCluster':
-    'No clusters available. Add a Kubernetes cluster to get started.',
+    'No clusters available. Register a Kubernetes cluster for GPU Service to get started.',
   'noresult.resources.worker':
     'No workers available. Add a worker to get started.',
   'noresult.resources.gotocluster': 'Create Your First Cluster',

--- a/src/locales/ja-JP/clusters.ts
+++ b/src/locales/ja-JP/clusters.ts
@@ -198,7 +198,17 @@ export default {
     'For on-demand GPU compute — e.g. interactive development, training jobs, or custom environments.',
   'clusters.gpuInstances.staticAddress': 'GPU Service Static Access Address',
   'clusters.gpuInstances.staticAddress.tip':
-    'Static address the operator uses to access GPU instances in this cluster (e.g. a LoadBalancer VIP). Optional.'
+    'Static address the operator uses to access GPU instances in this cluster (e.g. a LoadBalancer VIP). Operator default: empty — the access address is generated from host IPs. Changing it does not re-address GPU instances that are already deployed; it applies to newly created ones.',
+  'clusters.gpuInstances.derivedFromNode': 'Derive Instance Types from Nodes',
+  'clusters.gpuInstances.derivedFromNode.tip':
+    'Whether the operator auto-derives instance types (and their backing queues) from node hardware. Enabled: the operator authors a derived instance type for each node flavor. Disabled: it only aligns the resource flavor, and you define every instance type yourself. Operator default: Enabled.',
+  'clusters.gpuInstances.mixedOnNode': 'Allow Mixed Instance Types on a Node',
+  'clusters.gpuInstances.mixedOnNode.tip':
+    'Whether one node may serve both an accelerated and a CPU-only instance type. Enabled: a node is summarized into every type it can serve. Disabled: a node with accelerators yields only an accelerated type, and a CPU-only node only a general one. Operator default: Enabled.',
+  'clusters.gpuInstances.setting.enabled': 'Enabled',
+  'clusters.gpuInstances.setting.disabled': 'Disabled',
+  'clusters.gpuInstances.setting.unmanaged':
+    'Unmanaged (the cluster keeps its own value)'
 };
 
 // ========== To-Do: Translate Keys (Remove After Translation) ==========

--- a/src/locales/ja-JP/no-result.ts
+++ b/src/locales/ja-JP/no-result.ts
@@ -37,7 +37,7 @@ export default {
   'noresult.resources.cluster':
     'No clusters available. Add a cluster to get started.',
   'noresult.resources.k8sCluster':
-    'No clusters available. Add a Kubernetes cluster to get started.',
+    'No clusters available. Register a Kubernetes cluster for GPU Service to get started.',
   'noresult.resources.worker':
     'No workers available. Add a worker to get started.',
   'noresult.resources.gotocluster': 'Create Your First Cluster',

--- a/src/locales/ru-RU/clusters.ts
+++ b/src/locales/ru-RU/clusters.ts
@@ -199,7 +199,17 @@ export default {
     'For on-demand GPU compute — e.g. interactive development, training jobs, or custom environments.',
   'clusters.gpuInstances.staticAddress': 'GPU Service Static Access Address',
   'clusters.gpuInstances.staticAddress.tip':
-    'Static address the operator uses to access GPU instances in this cluster (e.g. a LoadBalancer VIP). Optional.'
+    'Static address the operator uses to access GPU instances in this cluster (e.g. a LoadBalancer VIP). Operator default: empty — the access address is generated from host IPs. Changing it does not re-address GPU instances that are already deployed; it applies to newly created ones.',
+  'clusters.gpuInstances.derivedFromNode': 'Derive Instance Types from Nodes',
+  'clusters.gpuInstances.derivedFromNode.tip':
+    'Whether the operator auto-derives instance types (and their backing queues) from node hardware. Enabled: the operator authors a derived instance type for each node flavor. Disabled: it only aligns the resource flavor, and you define every instance type yourself. Operator default: Enabled.',
+  'clusters.gpuInstances.mixedOnNode': 'Allow Mixed Instance Types on a Node',
+  'clusters.gpuInstances.mixedOnNode.tip':
+    'Whether one node may serve both an accelerated and a CPU-only instance type. Enabled: a node is summarized into every type it can serve. Disabled: a node with accelerators yields only an accelerated type, and a CPU-only node only a general one. Operator default: Enabled.',
+  'clusters.gpuInstances.setting.enabled': 'Enabled',
+  'clusters.gpuInstances.setting.disabled': 'Disabled',
+  'clusters.gpuInstances.setting.unmanaged':
+    'Unmanaged (the cluster keeps its own value)'
 };
 
 // ========== To-Do: Translate Keys (Remove After Translation) ==========

--- a/src/locales/ru-RU/no-result.ts
+++ b/src/locales/ru-RU/no-result.ts
@@ -38,7 +38,7 @@ export default {
   'noresult.resources.cluster':
     'No clusters available. Add a cluster to get started.',
   'noresult.resources.k8sCluster':
-    'No clusters available. Add a Kubernetes cluster to get started.',
+    'No clusters available. Register a Kubernetes cluster for GPU Service to get started.',
   'noresult.resources.worker':
     'No workers available. Add a worker to get started.',
   'noresult.resources.gotocluster': 'Create Your First Cluster',

--- a/src/locales/tr-TR/clusters.ts
+++ b/src/locales/tr-TR/clusters.ts
@@ -199,5 +199,15 @@ export default {
     'For on-demand GPU compute — e.g. interactive development, training jobs, or custom environments.',
   'clusters.gpuInstances.staticAddress': 'GPU Service Static Access Address',
   'clusters.gpuInstances.staticAddress.tip':
-    'Static address the operator uses to access GPU instances in this cluster (e.g. a LoadBalancer VIP). Optional.'
+    'Static address the operator uses to access GPU instances in this cluster (e.g. a LoadBalancer VIP). Operator default: empty — the access address is generated from host IPs. Changing it does not re-address GPU instances that are already deployed; it applies to newly created ones.',
+  'clusters.gpuInstances.derivedFromNode': 'Derive Instance Types from Nodes',
+  'clusters.gpuInstances.derivedFromNode.tip':
+    'Whether the operator auto-derives instance types (and their backing queues) from node hardware. Enabled: the operator authors a derived instance type for each node flavor. Disabled: it only aligns the resource flavor, and you define every instance type yourself. Operator default: Enabled.',
+  'clusters.gpuInstances.mixedOnNode': 'Allow Mixed Instance Types on a Node',
+  'clusters.gpuInstances.mixedOnNode.tip':
+    'Whether one node may serve both an accelerated and a CPU-only instance type. Enabled: a node is summarized into every type it can serve. Disabled: a node with accelerators yields only an accelerated type, and a CPU-only node only a general one. Operator default: Enabled.',
+  'clusters.gpuInstances.setting.enabled': 'Enabled',
+  'clusters.gpuInstances.setting.disabled': 'Disabled',
+  'clusters.gpuInstances.setting.unmanaged':
+    'Unmanaged (the cluster keeps its own value)'
 };

--- a/src/locales/tr-TR/no-result.ts
+++ b/src/locales/tr-TR/no-result.ts
@@ -39,7 +39,7 @@ export default {
   'noresult.resources.cluster':
     'Kullanılabilir küme yok. Başlamak için bir küme ekleyin.',
   'noresult.resources.k8sCluster':
-    'Kullanılabilir küme yok. Başlamak için bir Kubernetes kümesi ekleyin.',
+    'Kullanılabilir küme yok. Başlamak için GPU Hizmeti için bir Kubernetes kümesi kaydedin.',
   'noresult.resources.worker':
     'Kullanılabilir işçi düğüm yok. Başlamak için bir işçi düğüm ekleyin.',
   'noresult.resources.gotocluster': 'İlk Kümenizi Oluşturun',

--- a/src/locales/zh-CN/clusters.ts
+++ b/src/locales/zh-CN/clusters.ts
@@ -191,5 +191,14 @@ export default {
     '适用于按需分配 GPU 计算资源的场景，例如交互式开发、训练任务或自定义运行环境。',
   'clusters.gpuInstances.staticAddress': 'GPU 服务静态访问地址',
   'clusters.gpuInstances.staticAddress.tip':
-    'Operator 访问该集群 GPU 实例所使用的静态地址（例如 LoadBalancer VIP）。可选。'
+    'Operator 访问该集群 GPU 实例所使用的静态地址（例如 LoadBalancer VIP）。Operator 默认值：留空，此时访问地址由主机 IP 生成。修改后不会改写已部署实例的访问地址，仅对新建的实例生效。',
+  'clusters.gpuInstances.derivedFromNode': '从节点自动推导实例类型',
+  'clusters.gpuInstances.derivedFromNode.tip':
+    'Operator 是否根据节点硬件自动推导实例类型（及其对应的队列）。启用：Operator 为每种节点规格自动创建实例类型。禁用：Operator 仅对齐资源规格，实例类型全部由管理员自行定义。Operator 默认值：启用。',
+  'clusters.gpuInstances.mixedOnNode': '允许节点混合实例类型',
+  'clusters.gpuInstances.mixedOnNode.tip':
+    '同一个节点是否可以同时提供加速型和纯 CPU 实例类型。启用：节点会被归入其所能承载的每一种类型。禁用：带加速卡的节点只产生加速型实例类型，纯 CPU 节点只产生通用实例类型。Operator 默认值：启用。',
+  'clusters.gpuInstances.setting.enabled': '启用',
+  'clusters.gpuInstances.setting.disabled': '禁用',
+  'clusters.gpuInstances.setting.unmanaged': '未托管（沿用集群自身的设置）'
 };

--- a/src/locales/zh-CN/no-result.ts
+++ b/src/locales/zh-CN/no-result.ts
@@ -36,7 +36,7 @@ export default {
   'noresult.catalog.nofound': '未找到匹配的模型',
   'noresult.resources.cluster': '暂无可用集群，请添加集群以开始使用。',
   'noresult.resources.k8sCluster':
-    '暂无可用集群，请添加 Kubernetes 集群以开始使用。',
+    '暂无可用集群，请注册用于 GPU 服务的 Kubernetes 集群以开始使用。',
   'noresult.resources.worker': '暂无可用节点，请添加节点以开始使用。',
   'noresult.resources.gotocluster': '创建您的第一个集群',
   'noresult.resources.addk8scluster': '添加 Kubernetes 集群',

--- a/src/pages/cluster-management/components/cluster-form.tsx
+++ b/src/pages/cluster-management/components/cluster-form.tsx
@@ -241,7 +241,16 @@ const ClusterForm: React.FC<AddModalProps> = forwardRef(
 
     return (
       <FormContext.Provider
-        value={{ submitAttempted, clusterType, setClusterType }}
+        // `action` is what tells a nested field whether it is registering or
+        // editing; `currentData` only says whether values are present, which in
+        // the wizard is also true for a step the user has merely revisited.
+        value={{
+          action,
+          currentData,
+          submitAttempted,
+          clusterType,
+          setClusterType
+        }}
       >
         <Form
           name="clusterForm"

--- a/src/pages/cluster-management/components/k8s-pod-spec.tsx
+++ b/src/pages/cluster-management/components/k8s-pod-spec.tsx
@@ -3,6 +3,7 @@ import { PageActionType } from '@/config/types';
 import {
   CardRadioGroup,
   Input as CInput,
+  Select as CSelect,
   LabelSelector,
   type CardRadioOption
 } from '@gpustack/core-ui';
@@ -106,7 +107,7 @@ const experimentalBadgeStyle: React.CSSProperties = {
 // on the submitted payload. No standalone form field is registered; the click
 // only updates the shared `clusterType` state (see FormContext) — the payload's
 // `gpuInstanceOptions` shape is derived from it at submit (see cluster-form's
-// normalizeOutgoing), and the static-address field mounts/unmounts off it.
+// normalizeOutgoing), and the GPU Service settings mount/unmount off it.
 export const ClusterTypeSelector: React.FC = () => {
   const intl = useIntl();
   const { presetClusterType } = useStepsContext();
@@ -166,42 +167,157 @@ export const ClusterTypeSelector: React.FC = () => {
   );
 };
 
-// Static access address for GPU instances. Only shown when "GPU 服务" is
-// the selected cluster type. Rendered in the advanced section, between the
-// default container registry and the worker config (节点配置).
-export const GpuInstancesStaticAddressForm: React.FC = () => {
+// The two boolean operator settings are tri-state on the wire: absent/null
+// means GPUStack does not manage the setting and the cluster keeps its own
+// value, which is a different instruction from an explicit off — the settings
+// reconciler only ever writes a knob that is set. The form offers Enabled and
+// Disabled only; it never produces the unmanaged state, because an operator
+// default nobody chose is not a meaningful thing to ask an administrator
+// about.
+//
+// The options carry sentinel strings rather than booleans so the mapping to
+// and from the wire values stays on the Form.Item rather than in the Select.
+const SETTING_TRUE = 'true';
+const SETTING_FALSE = 'false';
+
+// Only an explicit value maps to an option; an unmanaged knob maps to none, so
+// the Select falls back to its placeholder. Showing Enabled there would be a
+// claim the form cannot support: Enabled is the operator's default, but a
+// cluster whose own setting was turned off by kubectl is Disabled, and an
+// unmanaged knob is exactly the case where GPUStack does not know which. Picking
+// a display value is also not free — it is the one an administrator would then
+// leave in place and save, turning "not managed" into an instruction.
+const toSettingOption = (value?: boolean | null) => {
+  if (value === true) return SETTING_TRUE;
+  if (value === false) return SETTING_FALSE;
+  return undefined;
+};
+
+// Only the two sentinels map to a boolean. The Select cannot currently emit
+// anything else — it has no allowClear — but mapping an absent value to `true`
+// would turn "not managed" into an explicit instruction the moment it could.
+const fromSettingOption = (value?: string) => {
+  if (value === SETTING_TRUE) return true;
+  if (value === SETTING_FALSE) return false;
+  return undefined;
+};
+
+const OperatorFlagForm: React.FC<{
+  name: string;
+  labelId: string;
+  descriptionId: string;
+  // Seed the store with `true` when the form is registering a new cluster, so
+  // "Enabled" is a value GPUStack actually persists rather than only a label.
+  // Never on edit: the whole block mounts with the Advanced panel's
+  // `forceRender`, so an initialValue there would land on any cluster whose
+  // knob is unmanaged and turn an untouched save into an explicit `true` —
+  // which the reconciler would then write over the cluster's own value.
+  seed: boolean;
+}> = ({ name, labelId, descriptionId, seed }) => {
   const intl = useIntl();
-  // Visibility tracks the shared cluster-type state (see FormContext), so this
-  // field mounts/unmounts deterministically with the selector. Its Form.Item is
-  // the only thing keeping gpuInstanceOptions alive, so unmounting it here (with
-  // the form's preserve={false}) also clears that path from the store.
-  const { clusterType } = useFormContext();
+
+  const options = useMemo(
+    () => [
+      {
+        value: SETTING_TRUE,
+        label: intl.formatMessage({
+          id: 'clusters.gpuInstances.setting.enabled'
+        })
+      },
+      {
+        value: SETTING_FALSE,
+        label: intl.formatMessage({
+          id: 'clusters.gpuInstances.setting.disabled'
+        })
+      }
+    ],
+    [intl]
+  );
+
+  return (
+    <SectionWrap>
+      <Form.Item
+        name={['k8s_options', 'gpuInstanceOptions', name]}
+        style={{ marginBottom: 0 }}
+        initialValue={seed ? true : undefined}
+        // getValueProps runs on every render — including after the edit form's
+        // setFieldsValue, which normalize would not see — so the two sentinels
+        // and the unmanaged placeholder stay in sync with the stored value.
+        getValueProps={(value) => ({ value: toSettingOption(value) })}
+        normalize={fromSettingOption}
+      >
+        <CSelect
+          label={intl.formatMessage({ id: labelId })}
+          description={intl.formatMessage({ id: descriptionId })}
+          placeholder={intl.formatMessage({
+            id: 'clusters.gpuInstances.setting.unmanaged'
+          })}
+          options={options}
+        ></CSelect>
+      </Form.Item>
+    </SectionWrap>
+  );
+};
+
+// The three GPUStack Operator settings that define a GPU Service cluster. Only
+// shown when "GPU 服务" is the selected cluster type. Rendered in the advanced
+// section, between the operator image and the worker config (节点配置).
+export const GpuServiceSettingsForm: React.FC = () => {
+  const intl = useIntl();
+  // Visibility tracks the shared cluster-type state (see FormContext), so these
+  // fields mount/unmount deterministically with the selector. Their Form.Items
+  // are the only thing keeping gpuInstanceOptions alive, so unmounting them
+  // here (with the form's preserve={false}) also clears that path from the
+  // store — and its presence is what marks the cluster as GPU Service.
+  const { clusterType, action } = useFormContext();
 
   if (clusterType !== 'gpu') {
     return null;
   }
 
+  // Seeded for a registration, never for an edit. Read from `action` rather
+  // than from `currentData`: the wizard passes each step back its own
+  // previously-entered values, so on a registration where the user stepped away
+  // and returned `currentData` is populated and `!currentData` would stop
+  // seeding — the same registration then persisting a different thing depending
+  // on which way the user walked through it.
+  const seed = action !== PageAction.EDIT;
+
   return (
-    <SectionWrap>
-      <Form.Item
-        name={[
-          'k8s_options',
-          'gpuInstanceOptions',
-          'gpuInstancesAccessStaticAddress'
-        ]}
-        style={{ marginBottom: 0 }}
-        normalize={(value) => value || null}
-      >
-        <CInput.Input
-          label={intl.formatMessage({
-            id: 'clusters.gpuInstances.staticAddress'
-          })}
-          description={intl.formatMessage({
-            id: 'clusters.gpuInstances.staticAddress.tip'
-          })}
-        ></CInput.Input>
-      </Form.Item>
-    </SectionWrap>
+    <>
+      <OperatorFlagForm
+        name="gpuInstanceTypeDerivedFromNode"
+        labelId="clusters.gpuInstances.derivedFromNode"
+        descriptionId="clusters.gpuInstances.derivedFromNode.tip"
+        seed={seed}
+      />
+      <OperatorFlagForm
+        name="gpuInstanceTypeMixedOnNode"
+        labelId="clusters.gpuInstances.mixedOnNode"
+        descriptionId="clusters.gpuInstances.mixedOnNode.tip"
+        seed={seed}
+      />
+      <SectionWrap>
+        <Form.Item
+          name={[
+            'k8s_options',
+            'gpuInstanceOptions',
+            'gpuInstancesAccessStaticAddress'
+          ]}
+          style={{ marginBottom: 0 }}
+          normalize={(value) => value || null}
+        >
+          <CInput.Input
+            label={intl.formatMessage({
+              id: 'clusters.gpuInstances.staticAddress'
+            })}
+            description={intl.formatMessage({
+              id: 'clusters.gpuInstances.staticAddress.tip'
+            })}
+          ></CInput.Input>
+        </Form.Item>
+      </SectionWrap>
+    </>
   );
 };
 

--- a/src/pages/cluster-management/config/form-context.ts
+++ b/src/pages/cluster-management/config/form-context.ts
@@ -1,9 +1,15 @@
+import { PageActionType } from '@/config/types';
 import { createContext, useContext } from 'react';
 import { ClusterListItem } from './types';
 
 // for cluster form
 interface FormContextProps {
   currentData?: ClusterListItem;
+  // Whether the form is creating or editing. Distinct from `currentData`: the
+  // registration wizard hands each step back its own previously-entered values
+  // as `currentData` when the user steps away and returns, so that field says
+  // "has values" rather than "is an existing cluster".
+  action?: PageActionType;
   submitAttempted?: boolean;
   // K8s cluster type. `gpuInstanceOptions` on the form is derived from this —
   // the selector, the static-address field, and submit all read this single

--- a/src/pages/cluster-management/config/types.ts
+++ b/src/pages/cluster-management/config/types.ts
@@ -79,7 +79,21 @@ export interface GpuInstanceOptions {
   // The mere presence of `gpuInstanceOptions` on `k8s_options` signals
   // "GPU instances enabled" for the cluster — absence opts the cluster out,
   // so there's no separate boolean flag on the wire.
+  //
+  // Every knob mirrors a GPUStack Operator setting of the same name and is
+  // tri-state: absent (or `null`) means GPUStack does not manage that setting
+  // and the cluster keeps its own value — a different instruction from an
+  // explicit `false`. The backend drops nulls when persisting, so `null` is
+  // how the form says "not managed".
+  //
+  // Keeps its legacy name — renaming it to the operator's
+  // `instance-access-static-address` would break the payload for every
+  // existing client, so the mismatch stays confined to this one field.
   gpuInstancesAccessStaticAddress?: string | null;
+  // Operator `instance-type-derived-from-node` (operator default: true).
+  gpuInstanceTypeDerivedFromNode?: boolean | null;
+  // Operator `instance-type-mixed-on-node` (operator default: true).
+  gpuInstanceTypeMixedOnNode?: boolean | null;
 }
 
 export interface K8sOptions {

--- a/src/pages/cluster-management/step-forms/advance-config.tsx
+++ b/src/pages/cluster-management/step-forms/advance-config.tsx
@@ -9,7 +9,7 @@ import { Button, Form } from 'antd';
 import React, { forwardRef, useEffect, useImperativeHandle } from 'react';
 import styled from 'styled-components';
 import {
-  GpuInstancesStaticAddressForm,
+  GpuServiceSettingsForm,
   OperatorImageForm
 } from '../components/k8s-pod-spec';
 import { ProviderType, ProviderValueMap } from '../config';
@@ -115,7 +115,7 @@ const ClusterAdvanceConfig: React.FC<{
       {provider === ProviderValueMap.Kubernetes && (
         <>
           <OperatorImageForm />
-          <GpuInstancesStaticAddressForm />
+          <GpuServiceSettingsForm />
         </>
       )}
       <Title>

--- a/src/pages/gpu-service/instance-types/config/types.ts
+++ b/src/pages/gpu-service/instance-types/config/types.ts
@@ -41,6 +41,11 @@ export interface InstanceTypeStatus {
 // Row shape for the management list (GET /gpu-instance-types).
 export interface ListItem {
   name: string;
+  // Hoisted by the backend out of the CR's `schedule.gpustack.ai/derived-from-node`
+  // label: the operator derived this type from a node instead of an admin
+  // creating it, so while the cluster derives types from nodes the operator
+  // owns its existence and re-creates it the moment it is deleted.
+  derivedFromNode?: boolean;
   spec: InstanceTypeSpec;
   status?: InstanceTypeStatus;
 }

--- a/src/pages/gpu-service/instance-types/hooks/use-instance-type-columns.tsx
+++ b/src/pages/gpu-service/instance-types/hooks/use-instance-type-columns.tsx
@@ -22,13 +22,18 @@ import { ListItem } from '../config/types';
 
 interface ColumnsHookProps {
   handleSelect: (val: string, record: ListItem) => void;
+  // Whether the cluster still derives instance types from its nodes. While it
+  // does, the operator re-creates a derived type as soon as it is deleted, so
+  // those rows offer no delete rather than one that cannot stick. Turning the
+  // setting off hands them back to the admin, delete included.
+  derivedFromNodeEnabled: boolean;
 }
 
 // DropdownButtons reads `locale` / `props` at runtime; its `items` prop is
 // typed as antd's MenuProps['items'], so cast the config to satisfy it. The
 // activate / deactivate action is chosen from the row's current phase: Active
 // types can be deactivated, Inactive ones activated (none while Preparing).
-const buildRowActions = (record: ListItem) => {
+const buildRowActions = (record: ListItem, derivedFromNodeEnabled: boolean) => {
   const phase = record.status?.phase;
   const actions: any[] = [];
   if (phase === InstanceTypePhaseValueMap.Active) {
@@ -51,6 +56,7 @@ const buildRowActions = (record: ListItem) => {
     key: 'delete',
     locale: true,
     icon: icons.DeleteOutlined,
+    disabled: derivedFromNodeEnabled && !!record.derivedFromNode,
     props: { danger: true }
   });
   return actions;
@@ -108,7 +114,8 @@ const TitleWithTip: React.FC<{ title: string; tip: string }> = ({
 );
 
 const useInstanceTypeColumns = ({
-  handleSelect
+  handleSelect,
+  derivedFromNodeEnabled
 }: ColumnsHookProps): ColumnsType<ListItem> => {
   const intl = useIntl();
 
@@ -258,13 +265,13 @@ const useInstanceTypeColumns = ({
         ellipsis: { showTitle: false },
         render: (_text, record: ListItem) => (
           <DropdownButtons
-            items={buildRowActions(record)}
+            items={buildRowActions(record, derivedFromNodeEnabled)}
             onSelect={(val: string) => handleSelect(val, record)}
           />
         )
       }
     ];
-  }, [handleSelect, intl]);
+  }, [handleSelect, derivedFromNodeEnabled, intl]);
 };
 
 export default useInstanceTypeColumns;

--- a/src/pages/gpu-service/instance-types/hooks/use-instance-type-columns.tsx
+++ b/src/pages/gpu-service/instance-types/hooks/use-instance-type-columns.tsx
@@ -56,6 +56,42 @@ const buildRowActions = (record: ListItem) => {
   return actions;
 };
 
+// Flavor identity for the column's sort (AC5.2): the same five fields the
+// operator resolves a cluster's Kueue pool by — acceleratable together with
+// acceleratorGroup/generalGroup, os, arch — not the observed status.detail
+// the cell renders below, so rows sharing a flavor sort adjacent even before
+// the operator backfills status.
+//
+// Compared field by field rather than through one JSON.stringify'd string: that
+// spelling sorted the JSON *text*, where `false` lands ahead of `true`
+// (`f` < `t`) and sank every accelerated row below the CPU-only ones. Nor can
+// the fields be joined into a single key — an acceleratorGroup or a product
+// name may contain whichever separator we picked, letting one field's value
+// bleed into the next field's comparison.
+const getFlavorSortFields = (record: ListItem) => [
+  // Accelerated first: this page exists for those rows.
+  record.spec?.acceleratable ? '0' : '1',
+  record.spec?.acceleratorGroup || '',
+  record.spec?.generalGroup || '',
+  record.spec?.os || '',
+  record.spec?.arch || '',
+  // Tiebreak within one flavor, so its rows keep an explicable order rather
+  // than the server's. The cell renders `product`, so that is what it sorts by.
+  record.status?.detail?.product || record.name
+];
+
+const compareByFlavor = (a: ListItem, b: ListItem) => {
+  const left = getFlavorSortFields(a);
+  const right = getFlavorSortFields(b);
+  for (let i = 0; i < left.length; i += 1) {
+    const diff = left[i].localeCompare(right[i]);
+    if (diff !== 0) {
+      return diff;
+    }
+  }
+  return 0;
+};
+
 // Column header with an info tooltip (used for the per-GPU resource columns).
 const TitleWithTip: React.FC<{ title: string; tip: string }> = ({
   title,
@@ -102,6 +138,8 @@ const useInstanceTypeColumns = ({
         dataIndex: ['status', 'detail', 'product'],
         key: 'product',
         ellipsis: { showTitle: false },
+        sorter: compareByFlavor,
+        defaultSortOrder: 'ascend',
         render: (_text: string, record: ListItem) => {
           const detail = record.status?.detail;
           return (

--- a/src/pages/gpu-service/instance-types/index.tsx
+++ b/src/pages/gpu-service/instance-types/index.tsx
@@ -161,7 +161,22 @@ const GPUServiceInstanceTypes: React.FC = () => {
     }
   });
 
-  const columns = useInstanceTypeColumns({ handleSelect });
+  // The operator owns the instance types it derived from a node only while the
+  // cluster's `instance-type-derived-from-node` setting is on. An unset knob
+  // means GPUStack does not manage the setting and the operator keeps its own
+  // default, which is on — so only an explicit `false` releases those types.
+  const derivedFromNodeEnabled = useMemo(() => {
+    const cluster = clusterList.find((item) => item.id === clusterId);
+    return (
+      cluster?.k8s_options?.gpuInstanceOptions
+        ?.gpuInstanceTypeDerivedFromNode !== false
+    );
+  }, [clusterList, clusterId]);
+
+  const columns = useInstanceTypeColumns({
+    handleSelect,
+    derivedFromNodeEnabled
+  });
 
   const filteredList = useMemo(() => {
     const trimmed = keyword.trim().toLowerCase();

--- a/src/pages/gpu-service/instance-types/index.tsx
+++ b/src/pages/gpu-service/instance-types/index.tsx
@@ -1,4 +1,3 @@
-import { ProviderValueMap } from '@/pages/cluster-management/config';
 import { useQueryClusterList } from '@/pages/cluster-management/services/use-query-cluster-list';
 import {
   BaseSelect,
@@ -49,25 +48,23 @@ const GPUServiceInstanceTypes: React.FC = () => {
     closeInstanceTypeModal
   } = useCreateInstanceTypeModal();
 
-  // Only Kubernetes clusters own GPU instance types.
-  const k8sClusters = useMemo(
-    () => clusterList.filter((c) => c.provider === ProviderValueMap.Kubernetes),
-    [clusterList]
-  );
-
-  // Fetch the visible clusters, default to the first Kubernetes one, then load
-  // its instance types. Action-driven: subsequent loads fire from the cluster
+  // Fetch the visible clusters, default to the first one, then load its
+  // instance types. Action-driven: subsequent loads fire from the cluster
   // picker / refresh, never from an effect dependency.
   useEffect(() => {
     const init = async () => {
-      const items = await fetchClusterList({ page: -1 });
-      const firstK8s = (items || []).find(
-        (c: any) => c.provider === ProviderValueMap.Kubernetes
-      );
-      if (firstK8s?.id != null) {
-        setClusterId(firstK8s.id);
-        await fetchInstanceTypes(firstK8s.id);
-        startWatch(firstK8s.id);
+      // Only clusters registered for GPU Service (k8s_options.gpu_instance_options
+      // set) are eligible here — a Model Service cluster must never appear in
+      // this picker.
+      const items = await fetchClusterList({
+        page: -1,
+        gpu_instance_enabled: true
+      });
+      const first = (items || [])[0];
+      if (first?.id != null) {
+        setClusterId(first.id);
+        await fetchInstanceTypes(first.id);
+        startWatch(first.id);
       }
       setLoaded(true);
     };
@@ -172,7 +169,7 @@ const GPUServiceInstanceTypes: React.FC = () => {
     return dataList.filter((item) => item.name.toLowerCase().includes(trimmed));
   }, [dataList, keyword]);
 
-  const hasK8sCluster = k8sClusters.length > 0;
+  const hasK8sCluster = clusterList.length > 0;
 
   const renderEmpty = (type?: string) => {
     if (type !== 'Table') return;
@@ -219,7 +216,7 @@ const GPUServiceInstanceTypes: React.FC = () => {
             variant="borderless"
             style={{ minWidth: 160 }}
             popupMatchSelectWidth={false}
-            options={k8sClusters}
+            options={clusterList}
             value={clusterId}
             onChange={handleClusterChange}
           />

--- a/src/pages/gpu-service/instances/README.md
+++ b/src/pages/gpu-service/instances/README.md
@@ -10,7 +10,7 @@ Three ways a cell says "no figure", and they mean different things:
 
 | Rendering | Meaning |
 | --- | --- |
-| `N/A` | The instance type has no accelerator, so a GPU / VRAM reading does not apply to this row at all |
+| blank | The instance type has no accelerator, so a GPU / VRAM reading does not apply to this row at all — absence rather than a placeholder, because a column of `N/A` reads louder than the gauges beside it |
 | `-` | The row's phase is outside `MetricsPollablePhases` (stopped, stopping, initializing) — nothing is being sampled, so a ring would frame a figure that is never coming |
 | `--` inside a ring | The row IS being polled and has not answered yet |
 
@@ -59,7 +59,7 @@ Three ways a cell says "no figure", and they mean different things:
 | Every gauge shows `--` inside a ring | Row phase is in `MetricsPollablePhases`? `clusterId` / `status.namespace` populated? Subresource 404 (operator < v0.8.2)? |
 | Only some rows show `--` | Those rows' phase / namespace, or their request hitting the 5s timeout |
 | Values frozen | An overlay or bulk confirmation is open, or the tab is in the background — i.e. `enabled` is false |
-| GPU / VRAM show `N/A` | `acceleratable` in the row's persisted type snapshot (`description`) |
+| GPU / VRAM cells are blank | `acceleratable` in the row's persisted type snapshot (`description`) |
 | Multi-card value looks wrong | Some card missing `used`/`total` — the aggregate then falls back to a per-card mean rather than mixing card sets |
 | Too many requests | `CONCURRENCY` / `POLL_INTERVAL`, and whether the page size was raised to 100 |
 | Table feels janky | Commit frequency (`COMMIT_WINDOW`), and whether something broke `UtilizationCell`'s memo by passing an unstable prop |

--- a/src/pages/gpu-service/instances/components/utilization-cell.tsx
+++ b/src/pages/gpu-service/instances/components/utilization-cell.tsx
@@ -100,9 +100,10 @@ const PerCardBars: React.FC<{
  * bar per card.
  *
  * Three ways a cell says "no figure", and they mean different things:
- *   - "N/A": the instance type has no accelerator, so a GPU / VRAM reading does
- *     not apply to this row at all — the same wording the workers table uses for
- *     a resource a row cannot report;
+ *   - blank: the instance type has no accelerator, so a GPU / VRAM reading does
+ *     not apply to this row at all. It reads as absence rather than as a
+ *     placeholder on purpose — a column of "N/A" is louder than the readings
+ *     beside it, and a CPU-only row has nothing to say here;
  *   - a single "-": the row's phase has no Pod behind it (stopped, stopping,
  *     still initializing), so no sample is coming — an empty ring would frame a
  *     reading that will never arrive;
@@ -125,7 +126,7 @@ const UtilizationCell: React.FC<{
   const isAcceleratorGauge = _.includes(AcceleratorGaugeKeys, gaugeKey);
 
   if (isAcceleratorGauge && !hasAccelerators) {
-    return <span className={styles.notApplicable}>N/A</span>;
+    return null;
   }
 
   if (!measurable) {

--- a/src/pages/gpu-service/instances/hooks/use-instances-columns.tsx
+++ b/src/pages/gpu-service/instances/hooks/use-instances-columns.tsx
@@ -25,6 +25,7 @@ import {
 } from '../config';
 import {
   InstanceMetricsMap,
+  InstanceServicePort,
   InstanceTypeSnapshotSpec,
   ListItem
 } from '../config/types';
@@ -76,10 +77,20 @@ type ConnectEntry =
       protocol: string;
     };
 
+const isSshPort = (p: InstanceServicePort) =>
+  (p.protocol === 'TCP' && p.port === 22) ||
+  _.includes(_.toLower(p.name), 'ssh');
+
 const getConnectEntries = (record: ListItem): ConnectEntry[] => {
   const ip = record.status?.accessAddresses?.[0];
   const ports = record.status?.ports || [];
   const configPorts = record.spec?.ports || [];
+  // Every instance is created with a tcp/22 port, whether or not SSH was
+  // enabled — that is deliberate, so a public key can be attached later by
+  // updating the instance instead of recreating its Pod. The open port is
+  // therefore not a way in on its own: with no key there is nothing to
+  // authenticate with, so SSH is offered only once a key is actually attached.
+  const hasSshKey = !!record.spec?.sshPublicKeys?.length;
 
   if (!ip) {
     return [];
@@ -87,11 +98,9 @@ const getConnectEntries = (record: ListItem): ConnectEntry[] => {
 
   return ports
     .filter((p) => p.nodePort)
+    .filter((p) => hasSshKey || !isSshPort(p))
     .map<ConnectEntry>((p) => {
-      const isSsh =
-        (p.protocol === 'TCP' && p.port === 22) ||
-        _.includes(_.toLower(p.name), 'ssh');
-      if (isSsh) {
+      if (isSshPort(p)) {
         return {
           type: 'ssh',
           name: 'SSH',

--- a/src/pages/gpu-service/instances/index.tsx
+++ b/src/pages/gpu-service/instances/index.tsx
@@ -123,7 +123,11 @@ const GPUService: React.FC = () => {
   >({});
 
   useEffect(() => {
-    fetchClusterList({ page: -1 });
+    // Only clusters registered for GPU Service (k8s_options.gpu_instance_options
+    // set) are eligible here — a Model Service cluster's capacity is committed
+    // to model deployment, not GPU Instances, so it must never appear in this
+    // picker.
+    fetchClusterList({ page: -1, gpu_instance_enabled: true });
     const fetchPVCapacities = async () => {
       try {
         const res = await queryGPUServiceStorage({ page: -1 } as any);
@@ -141,10 +145,9 @@ const GPUService: React.FC = () => {
     fetchPVCapacities();
   }, []);
 
-  const hasK8sCluster = useMemo(
-    () => clusterList.some((c) => c.provider === ProviderValueMap.Kubernetes),
-    [clusterList]
-  );
+  // gpu_instance_enabled: true already scopes clusterList to GPU Service
+  // clusters, so any cluster present is one this page can use.
+  const hasK8sCluster = useMemo(() => clusterList.length > 0, [clusterList]);
 
   const handleModalOk = async (data: FormData) => {
     try {

--- a/src/pages/gpu-service/instances/styles/utilization-cell.module.less
+++ b/src/pages/gpu-service/instances/styles/utilization-cell.module.less
@@ -1,13 +1,6 @@
 // Utilization column: a row of small half-ring gauges, plus the per-card
 // breakdown a multi-card gauge shows on hover.
 
-// "This row has no accelerator" — the weakest of the three empty states, since
-// it is a statement about the instance type rather than about the reading.
-.notApplicable {
-  font-size: 12px;
-  color: var(--ant-color-text-tertiary);
-}
-
 // "No sample is coming" (stopped, stopping, initializing). Carries the weight
 // and tone of the gauge's own text, so a column of stopped and running rows
 // reads as one column — it just has no ring around it.

--- a/src/pages/llmodels/forms/vgpu-type.tsx
+++ b/src/pages/llmodels/forms/vgpu-type.tsx
@@ -72,10 +72,43 @@ const getSliceModeFromValues = (selector: any): SliceMode => {
   return 'whole';
 };
 
-// Dropdown option for a GPU type: its display name, over the hardware that
-// tells two types apart at a glance — vendor, VRAM and architecture. The
-// vendor and memory are observed (status.detail), the arch is definitional
-// (spec); any of them can be absent on a type the operator has not backfilled.
+// Flavor identity for GPU Type deduplication (F6): several InstanceTypes can
+// share a flavor (same acceleratable/acceleratorGroup/generalGroup/os/arch)
+// and differ only in unit resources. Deduplication on this key is safe
+// because the model deploy path never reads an instance type's unit
+// resources — gpu_type_selector is translated into the accelerator resource
+// base plus slicing keys only (worker/backends/base.py:605-650), and
+// validation resolves the type by name to read its hardware detail and
+// slicing capability (routes/models.py:493), both properties of the flavor
+// rather than the unit spec. Do not "fix" this back to one option per type.
+const getFlavorKey = (item: InstanceTypeListItem) => {
+  // Every type here is accelerated (the fetch above filters on it), so
+  // acceleratorGroup is what identifies the flavor. Until the operator has
+  // resolved one, grouping on it would collapse every unresolved type into a
+  // single option — unrelated GPUs merged behind one label, with the losers
+  // unselectable and no error anywhere to say why. A type without a group
+  // therefore groups with nothing: a redundant option is recoverable, a GPU
+  // the user cannot deploy to and cannot see is not.
+  if (!item.spec?.acceleratorGroup) {
+    return `name:${item.name}`;
+  }
+  return JSON.stringify([
+    item.spec?.acceleratable,
+    item.spec?.acceleratorGroup,
+    item.spec?.generalGroup,
+    item.spec?.os,
+    item.spec?.arch
+  ]);
+};
+
+// Dropdown option for a GPU type: after dedup (getFlavorKey below) each
+// option represents a flavor, so its headline is the observed hardware
+// product rather than spec.displayName — displayName is free-form
+// per-instance-type text an administrator sets to tell several same-flavor
+// types apart (e.g. by unit size), so it cannot label the flavor once they
+// are collapsed into one option. The vendor and VRAM (observed, status.detail)
+// plus arch (definitional, spec) sit on the line below; any of them can be
+// absent on a type the operator has not backfilled.
 const GPUTypeOption: React.FC<{ item: InstanceTypeListItem }> = ({ item }) => {
   const detail = item.status?.detail;
   const manufacturer = detail?.manufacturer || '';
@@ -87,7 +120,7 @@ const GPUTypeOption: React.FC<{ item: InstanceTypeListItem }> = ({ item }) => {
   return (
     <Flex vertical gap={4} style={{ minWidth: 0, padding: '2px 0' }}>
       <AutoTooltip ghost minWidth={20}>
-        {item.spec?.displayName || item.name}
+        {detail?.product || item.name}
       </AutoTooltip>
       <Flex
         align="center"
@@ -244,16 +277,67 @@ const VGPUTypeForm: React.FC = () => {
   // directly, and neither means a whole card with no controls.
   const showModeSwitch = supportsSliced && supportsPartitioned;
 
-  const typeOptions = useMemo(
-    () =>
-      typeList.map((item) => ({
-        label: item.spec?.displayName || item.name,
-        value: item.name,
-        instanceType: item,
-        disabled: !isTypeRequestable(item)
-      })),
-    [typeList]
-  );
+  // One option per flavor (F6/AC6.1, AC6.3): several instance types sharing a
+  // flavor are indistinguishable for this decision (see getFlavorKey), so
+  // only their representative — the lowest name, chosen deterministically so
+  // the list does not reorder between renders (AC6.2) — becomes an option.
+  // typeList itself stays undeduplicated so a previously-submitted selection
+  // still resolves to its own record above.
+  //
+  // The representative's record is what the mode gating below reads, and two
+  // of those reads are live ledgers rather than flavor properties:
+  // `status.acceleratorSliced.onceMaxRequest` and
+  // `status.acceleratorPartitioned.remainingProfiles`. That is only safe
+  // because the operator computes them per flavor pool, not per type —
+  // measured on a two-card RTX 4090 node carrying two types over one flavor,
+  // both reported onceMaxRequest=100 remaining=200 with one card already
+  // taken by each. It is the operator's behaviour rather than a contract, so
+  // if a type ever reports a ledger of its own, the representative would start
+  // gating its siblings and this dedup would need the max across the group.
+  const typeOptions = useMemo(() => {
+    const byFlavor = new Map<string, InstanceTypeListItem>();
+    typeList.forEach((item) => {
+      const key = getFlavorKey(item);
+      const representative = byFlavor.get(key);
+      if (!representative || item.name < representative.name) {
+        byFlavor.set(key, item);
+      }
+    });
+    const entries = Array.from(byFlavor.values()).map((item) => ({
+      label: item.status?.detail?.product || item.name,
+      value: item.name,
+      instanceType: item,
+      disabled: !isTypeRequestable(item)
+    }));
+
+    // A stored selection is whatever was submitted, which may be a type this
+    // dedup did not pick as its flavor's representative — nothing ever rewrote
+    // those names. Antd falls back to the raw value when no option carries it,
+    // so without this the field of an edit form nobody touched reads as a bare
+    // resource name. Its label leads with displayName, unlike a
+    // representative's: this option sits beside one that already shows the
+    // product name, and displayName is precisely the text an administrator set
+    // to tell same-flavor types apart.
+    if (
+      selectedInstanceType &&
+      !entries.some((entry) => entry.value === selectedInstanceType.name)
+    ) {
+      entries.push({
+        label:
+          selectedInstanceType.spec?.displayName ||
+          selectedInstanceType.status?.detail?.product ||
+          selectedInstanceType.name,
+        value: selectedInstanceType.name,
+        instanceType: selectedInstanceType,
+        disabled: !isTypeRequestable(selectedInstanceType)
+      });
+    }
+
+    // Sorted, not left in Map insertion order: that order is the server's,
+    // so a reordered list would reorder the dropdown even though the
+    // representatives themselves did not change.
+    return entries.sort((a, b) => a.value.localeCompare(b.value));
+  }, [typeList, selectedInstanceType]);
 
   // Single commit path for mode switches (form-patterns): write every
   // mode-specific field together so no stale value from the previous mode

--- a/src/pages/llmodels/hooks/use-form-initial-values.ts
+++ b/src/pages/llmodels/hooks/use-form-initial-values.ts
@@ -200,6 +200,12 @@ export const useGenerateWorkerOptions = () => {
       }),
       queryClusterList({
         page: -1,
+        // Exclude clusters that opt in to GPU-instance handling
+        // (k8s_options.gpu_instance_options set) — those are for the
+        // GPU-service flow, not model deployment. This feeds the
+        // deploy-from-model-file cluster picker, so a GPU Service cluster
+        // must not appear here either.
+        gpu_instance_enabled: false,
         // Own-org clusters only. Feeds the deploy-from-model-file cluster
         // picker, which must not offer another org's cluster (e.g. the
         // Default org's "shared with everyone" clusters). The worker


### PR DESCRIPTION
## Summary

Frontend counterpart to gpustack/gpustack#6062. A cluster is either a **Model Service** or a **GPU Service** cluster; the GPU Service pages did not respect that, and the cluster form only exposed one of the three settings the operator actually has.

- **Cluster pickers filter by purpose.** GPU Service → Instances and Instance Types request `gpu_instance_enabled: true` and drop the client-side `provider === Kubernetes` check, which a GPU Service cluster satisfies by construction. The Deployment pickers keep passing `false` — including the deploy-from-model-file one, which passed only `mine`.
- **All three operator settings at registration.** The GPU Service branch of the cluster form renders them with the operator's own default and effect as help text. The two knobs offer **Enabled / Disabled** and default to Enabled, which is also the operator's default, so no cluster behaves differently — only who is on record as having chosen it. The payload still accepts `null` for "not managed"; the form simply never produces one.
- **One entry per flavor in the slicing GPU Type list.** Several instance types over one flavor were indistinguishable choices for that decision. The representative is the lowest name, so the list does not reorder between renders.
- **A sortable Flavor column** on Instance Types, so several types over one pool group together.
- **CPU-only rows leave the accelerator cells blank** instead of printing `N/A` next to real gauges.

## The one that needs a second pair of eyes

`initialValue={true}` on the two knob Selects was not confined to registration. The Advanced Config panel renders with `forceRender`, so the block mounts on **every** edit-modal open even while collapsed, and rc-field-form applies a field-level `initialValue` whenever the store path is `undefined` — which is exactly the shape of a cluster whose knobs are unmanaged.

Measured on a live cluster before the fix: knobs `{}` plus an administrator's `kubectl`-set `Setting` of `false`; open Edit, change only the description, save → knobs came back as both `true` and the reconciler patched the `Setting` back to `true`. After: knobs stay `{}` and the `Setting` stays `false`.

The seed now fires only when registering a new cluster. `FormContext` declared `currentData` but never provided it, so the first attempt at this fix was inert — the provider passes it now.

## Verified live

Against the packaged image on a two-node k3s cluster, captured from the browser's own network log:

```
GPU Service > Instance Types  ->  GET /v2/clusters?page=-1&gpu_instance_enabled=true
GPU Service > GPU Instances   ->  GET /v2/clusters?page=-1&gpu_instance_enabled=true
```

The picker offers only the GPU Service cluster; with none visible, both pages render their empty state rather than a blank picker. Selecting Model Service in the form unmounts all three settings — asserted against the rendered document, not just visually.

## Known, not fixed here

The GPU Instances table's select-all checkbox does nothing. `@gpustack/core-ui@1.1.5` wires `onSelectAll` only on the `expandable && enableSelection` branch of its header prefix; this table is selectable but not expandable, so it renders a checkbox with no handler. Not fixable from this repo. Recorded in https://github.com/gpustack/gpustack/issues/6063.
