### PR TITLE
fix(models): disable unusable GPU types and keep evaluation off half-typed slices

### DIFF
--- a/src/pages/llmodels/forms/vgpu-type.tsx
+++ b/src/pages/llmodels/forms/vgpu-type.tsx
@@ -27,6 +27,38 @@ const SLICE_PERCENT_TICKS = [10, 20, 30, 50];
 
 type SliceMode = 'whole' | 'sliced' | 'partitioned';
 
+// Whether a GPU type can still take a request under GPU Allocation = Slicing.
+//
+// Only a type that OFFERS a mode can run out of it. A type offering neither
+// mode is not exhausted, it is simply whole-card: the form forces mode 'whole'
+// for it and submits a 0/0 selector, which is a valid request — so it stays
+// selectable. What gets disabled is the type that offers slicing or
+// partitioning and has nothing left to hand out, where picking it could only
+// end in the "choose another GPU type" notice.
+//
+// The capacity halves read the live per-flavor ledgers, the same ones the
+// selected type's mode gating below reads — capability alone is not enough, a
+// type whose pool is full still declares itself sliceable.
+const isTypeRequestable = (item: InstanceTypeListItem) => {
+  const detail = item.status?.detail?.slicedDetail;
+  const offersSliced = isLogicalSliceable(detail);
+  const offersPartitioned = isPhysicalSliceable(detail);
+  if (!offersSliced && !offersPartitioned) {
+    return true;
+  }
+
+  const slicedLeft =
+    _.toNumber(item.status?.acceleratorSliced?.onceMaxRequest) || 0;
+  const canSlice = offersSliced && slicedLeft > 0;
+  const canPartition =
+    offersPartitioned &&
+    getSelectablePartitionProfilesFromResource(
+      item.status?.acceleratorPartitioned,
+      detail
+    ).length > 0;
+  return canSlice || canPartition;
+};
+
 // Derive the mode from the persisted selector values (edit hydration): a
 // partition profile means partitioned, positive percentages mean sliced,
 // anything else is a whole card.
@@ -217,7 +249,8 @@ const VGPUTypeForm: React.FC = () => {
       typeList.map((item) => ({
         label: item.spec?.displayName || item.name,
         value: item.name,
-        instanceType: item
+        instanceType: item,
+        disabled: !isTypeRequestable(item)
       })),
     [typeList]
   );

--- a/src/pages/llmodels/hooks/index.ts
+++ b/src/pages/llmodels/hooks/index.ts
@@ -172,6 +172,34 @@ export const useCheckCompatibility = () => {
     });
   };
 
+  // A slice request is only valid as a pair, and the API is specific about
+  // which halves it accepts (GPUTypeSelector.normalize_slice_percentages):
+  // memory must be 1-100, while cores may be absent — it defaults to 100 —
+  // but not an explicit 0. Anything else is not a smaller request, it is an
+  // unparseable one. So leave a request the API would accept (or a partition
+  // profile) untouched, and reduce the rest to the whole-card pair it
+  // normalizes an all-zero selector to, which costs a half-typed selector
+  // nothing. Leaving an absent cores percentage absent matters: forcing it to
+  // a pair here would evaluate a whole card for a request the API reads as
+  // memory% / 100%.
+  const normalizeSelectorForEvaluate = (selector: any) => {
+    if (selector.accelerator_partitioned_profile) {
+      return selector;
+    }
+    const cores = selector.accelerator_sliced_cores_percentage;
+    const coresSet = cores !== null && cores !== undefined && cores !== '';
+    const memorySliced =
+      _.toNumber(selector.accelerator_sliced_memory_percentage) > 0;
+    if (memorySliced && (!coresSet || _.toNumber(cores) > 0)) {
+      return selector;
+    }
+    return {
+      ...selector,
+      accelerator_sliced_memory_percentage: 0,
+      accelerator_sliced_cores_percentage: 0
+    };
+  };
+
   const handleEvaluate = async (data: any) => {
     try {
       // when no cluster selected, show warning and prompt user to add cluster first
@@ -209,6 +237,22 @@ export const useCheckCompatibility = () => {
                 'manualGpuMode',
                 'scaling_schedule'
               ]),
+              // Same reasoning for the vGPU selector, which the form walks
+              // through an incomplete state on every GPU-type switch: the new
+              // type's capacity may not admit the percentage the previous one
+              // carried, leaving a cores percentage without a memory one,
+              // which the API rejects outright (GpuTypeSelector rejects a
+              // sliced request whose memory percentage is not 1-100). The
+              // whole evaluation would 422 on a half-typed request and surface
+              // as an error toast, so evaluate the equivalent whole-card
+              // request instead.
+              ...(data.gpu_type_selector
+                ? {
+                    gpu_type_selector: normalizeSelectorForEvaluate(
+                      data.gpu_type_selector
+                    )
+                  }
+                : {}),
               categories: Array.isArray(data.categories)
                 ? data.categories
                 : data.categories


### PR DESCRIPTION
## Summary

Two fixes in the Slicing scheduling form (**Deployments → Scheduling → GPU Allocation → Slicing**), both reported from a cluster whose sliceable capacity had run out.

### A GPU type with nothing left to give was still selectable

Picking it could only ever end in the *"No sliceable capacity available on this GPU type, please choose another GPU type"* notice, with no way to submit — the form even carries a deliberately always-failing validator to stop that submit. The option is now `disabled` instead.

The predicate asks whether the type can still take a request **in either mode**: sliceable capacity left, or a partition profile to hand out. Capability flags alone would be the wrong test — a type whose pool is full still declares itself sliceable — so it reads the same live per-flavor ledgers (`status.acceleratorSliced.onceMaxRequest`, `status.acceleratorPartitioned`) that the *selected* type's mode gating already reads.

### Switching GPU types raised a validation error toast

Not on submit — on **every keystroke of the form**. The compatibility check (`POST /v2/model-evaluations`) is fired from `onValuesChange` with the form's full current values, and switching GPU types walks through an incomplete selector: the new type's capacity may not admit the percentage the previous one carried, leaving a cores percentage without a memory one. The API rejects that outright:

```
1 validation errors: {'type': 'value_error', 'loc': ('body', 'model_specs', 0, 'gpu_type_selector'),
 'msg': 'Value error, accelerator_sliced_memory_percentage is required in the range 1-100 …'}
```

so the whole evaluation 422'd and surfaced as an error toast while the user was still editing.

The selector is now normalized to the equivalent whole-card request before evaluating — which is what the API itself normalizes an all-zero pair to. This mirrors the reason `scaling_schedule` is already dropped from that same call ("*so in-progress (possibly incomplete) rules never fail the evaluate request*"); `gpu_type_selector` is the same class of problem and was simply not covered.

## Test plan

Verified on a live cluster (k3s + gpustack-operator v0.8.3) with the RTX 4090 pool deliberately exhausted (`acceleratorSliced.onceMaxRequest = 0`) and the Radeon RX 7800 XT pool free (`= 100`):

- **before**, both dropdown options reported `disabled: false`; **after**, the 4090 is `disabled: true` and renders greyed out, the AMD type stays selectable;
- the API's own validator was exercised directly over the four shapes: mid-switch `memory=None, cores=100` → rejected, `memory=0, cores=100` → rejected, normalized `0/0` → accepted, and a complete `50/100` request → accepted unchanged (so a real slice request is not touched);
- submit was never at risk: walking `NVIDIA → AMD → NVIDIA → Save` in the edit form, the existing validator blocked it and **no request was sent** — the bug only ever affected the evaluation toast, never persisted data.

`tsc` clean on both files, `npm run build` passes.

Note: fixing the first issue closes the route to the second one through the UI (an unusable type can no longer be selected, so that mid-switch state is no longer reachable that way). The normalization stays as defence in depth for the other paths that can leave the selector incomplete — capacity being taken by someone else while the form is open, for instance.
