### PR TITLE
feat(maas-provider): support custom Anthropic URL for claude provider

### DIFF
--- a/src/locales/en-US/provider.ts
+++ b/src/locales/en-US/provider.ts
@@ -17,11 +17,18 @@ export default {
   'providers.form.target.placeholder': 'provider/models',
   'providers.form.fallback.token': 'Fallback API Keys',
   'providers.form.custombeckendUrl': 'Custom Base URL',
+  'providers.form.claudeCustomUrl': 'Custom API URL',
+  'providers.form.claudeCustomUrl.tips':
+    'When set, this provider serves the Anthropic protocol (/v1/messages) only, and OpenAI-style requests are not converted. Leave it empty to use api.anthropic.com through the OpenAI protocol.',
   'providers.form.more': '+{count} more',
   'providers.form.addAll': 'Add All',
   'providers.form.rules.models': 'Please select at least one model',
   'providers.form.rules.tokens': 'Please enter a valid API Key',
   'providers.form.rules.model': 'Please select a model',
+  'providers.form.rules.absoluteHttpUrl':
+    'Please enter an absolute http(s) URL, including the port if there is one, e.g. https://gateway.example.com:8080',
+  'providers.form.rules.openaiCustomUrl':
+    'Please enter an absolute http(s) URL with a path, e.g. https://gateway.example.com:8080/v1',
   'providers.form.model.duplicate': 'Duplicate model exists',
   'providers.table.registerRoute': 'Register Route',
   'providers.form.azureServiceUrl': 'Azure OpenAI Service URL',

--- a/src/locales/ja-JP/provider.ts
+++ b/src/locales/ja-JP/provider.ts
@@ -17,11 +17,18 @@ export default {
   'providers.form.target.placeholder': 'provider/models',
   'providers.form.fallback.token': 'Fallback API Keys',
   'providers.form.custombeckendUrl': 'Custom Base URL',
+  'providers.form.claudeCustomUrl': 'Custom API URL',
+  'providers.form.claudeCustomUrl.tips':
+    'When set, this provider serves the Anthropic protocol (/v1/messages) only, and OpenAI-style requests are not converted. Leave it empty to use api.anthropic.com through the OpenAI protocol.',
   'providers.form.more': '+{count} more',
   'providers.form.addAll': 'Add All',
   'providers.form.rules.models': 'Please select at least one model',
   'providers.form.rules.tokens': 'Please enter a valid API Key',
   'providers.form.rules.model': 'Please select a model',
+  'providers.form.rules.absoluteHttpUrl':
+    'Please enter an absolute http(s) URL, including the port if there is one, e.g. https://gateway.example.com:8080',
+  'providers.form.rules.openaiCustomUrl':
+    'Please enter an absolute http(s) URL with a path, e.g. https://gateway.example.com:8080/v1',
   'providers.form.model.duplicate': 'Duplicate model exists',
   'providers.table.registerRoute': 'Register Route',
   'providers.form.azureServiceUrl': 'Azure OpenAI Service URL',

--- a/src/locales/ru-RU/provider.ts
+++ b/src/locales/ru-RU/provider.ts
@@ -17,11 +17,18 @@ export default {
   'providers.form.target.placeholder': 'provider/models',
   'providers.form.fallback.token': 'Fallback API Keys',
   'providers.form.custombeckendUrl': 'Custom Base URL',
+  'providers.form.claudeCustomUrl': 'Custom API URL',
+  'providers.form.claudeCustomUrl.tips':
+    'When set, this provider serves the Anthropic protocol (/v1/messages) only, and OpenAI-style requests are not converted. Leave it empty to use api.anthropic.com through the OpenAI protocol.',
   'providers.form.more': '+{count} more',
   'providers.form.addAll': 'Add All',
   'providers.form.rules.models': 'Please select at least one model',
   'providers.form.rules.tokens': 'Please enter a valid API Key',
   'providers.form.rules.model': 'Please select a model',
+  'providers.form.rules.absoluteHttpUrl':
+    'Please enter an absolute http(s) URL, including the port if there is one, e.g. https://gateway.example.com:8080',
+  'providers.form.rules.openaiCustomUrl':
+    'Please enter an absolute http(s) URL with a path, e.g. https://gateway.example.com:8080/v1',
   'providers.form.model.duplicate': 'Duplicate model exists',
   'providers.table.registerRoute': 'Register Route',
   'providers.form.azureServiceUrl': 'Azure OpenAI Service URL',

--- a/src/locales/tr-TR/provider.ts
+++ b/src/locales/tr-TR/provider.ts
@@ -17,11 +17,18 @@ export default {
   'providers.form.target.placeholder': 'sağlayıcı/modeller',
   'providers.form.fallback.token': 'Yedek API Anahtarları',
   'providers.form.custombeckendUrl': 'Özel Temel URL',
+  'providers.form.claudeCustomUrl': "Özel API URL'si",
+  'providers.form.claudeCustomUrl.tips':
+    'Ayarlandığında bu sağlayıcı yalnızca Anthropic protokolünü (/v1/messages) sunar ve OpenAI biçimindeki istekler dönüştürülmez. Boş bırakılırsa api.anthropic.com adresi OpenAI protokolü üzerinden kullanılır.',
   'providers.form.more': '+{count} daha fazla',
   'providers.form.addAll': 'Tümünü Ekle',
   'providers.form.rules.models': 'Lütfen en az bir model seçin',
   'providers.form.rules.tokens': 'Lütfen geçerli bir API Anahtarı girin',
   'providers.form.rules.model': 'Lütfen bir model seçin',
+  'providers.form.rules.absoluteHttpUrl':
+    'Lütfen şema içeren tam bir http(s) adresi girin (varsa portu da ekleyin), örneğin https://gateway.example.com:8080',
+  'providers.form.rules.openaiCustomUrl':
+    'Lütfen şema ve yol içeren tam bir http(s) adresi girin, örneğin https://gateway.example.com:8080/v1',
   'providers.form.model.duplicate': 'Yinelenen model mevcut',
   'providers.table.registerRoute': 'Yönlendirme Kaydet',
   'providers.form.azureServiceUrl': "Azure OpenAI Hizmet URL'si",

--- a/src/locales/zh-CN/provider.ts
+++ b/src/locales/zh-CN/provider.ts
@@ -17,11 +17,18 @@ export default {
   'providers.form.target.placeholder': '提供商/模型',
   'providers.form.fallback.token': '备用 API Key',
   'providers.form.custombeckendUrl': '自定义 Base URL',
+  'providers.form.claudeCustomUrl': '自定义 API 地址',
+  'providers.form.claudeCustomUrl.tips':
+    '填写后该提供商仅提供 Anthropic 协议（/v1/messages），OpenAI 协议的请求不会被转换。留空则使用 api.anthropic.com 并通过 OpenAI 协议访问。',
   'providers.form.more': '+{count} 更多',
   'providers.form.addAll': '添加全部',
   'providers.form.rules.models': '请选择至少一个模型',
   'providers.form.rules.tokens': '请输入有效的 API Key',
   'providers.form.rules.model': '请选择模型',
+  'providers.form.rules.absoluteHttpUrl':
+    '请输入带协议的完整地址（如有端口需一并写明），例如 https://gateway.example.com:8080',
+  'providers.form.rules.openaiCustomUrl':
+    '请输入带协议和路径的完整地址，例如 https://gateway.example.com:8080/v1',
   'providers.form.model.duplicate': '存在相同的模型',
   'providers.table.registerRoute': '注册路由',
   'providers.form.azureServiceUrl': 'Azure OpenAI 服务 URL',

--- a/src/pages/maas-provider/config/form-context.ts
+++ b/src/pages/maas-provider/config/form-context.ts
@@ -10,6 +10,7 @@ interface FormContextProps {
   id?: number;
   providerFields?: RequiredFields[];
   getCustomConfig?: () => Record<string, any>;
+  resetCustomConfig?: () => void;
 }
 
 const FormContext = createContext<FormContextProps>({} as FormContextProps);

--- a/src/pages/maas-provider/config/types.ts
+++ b/src/pages/maas-provider/config/types.ts
@@ -15,7 +15,8 @@ export interface FormData {
   proxy_enabled?: boolean;
   config: {
     type: maasProviderType;
-    openaiCustomUrl?: string;
+    openaiCustomUrl?: string | null;
+    claudeCustomUrl?: string | null;
     [key: string]: any;
   };
 }
@@ -27,7 +28,8 @@ export interface MaasProviderItem {
   proxy_timeout: number;
   config: {
     type: maasProviderType;
-    openaiCustomUrl?: string;
+    openaiCustomUrl?: string | null;
+    claudeCustomUrl?: string | null;
     [key: string]: any;
   };
   id: number;
@@ -51,7 +53,13 @@ export interface RequiredFields {
   };
   required?: boolean;
   placeholder?: string;
+  // tooltip on the label
   description?: {
+    text: string;
+    locale?: boolean;
+  };
+  // hint line rendered below the field
+  hint?: {
     text: string;
     locale?: boolean;
   };

--- a/src/pages/maas-provider/forms/basic.tsx
+++ b/src/pages/maas-provider/forms/basic.tsx
@@ -20,7 +20,7 @@ const Basic: React.FC<{
 }> = ({ onAPIKeyBlur }) => {
   const intl = useIntl();
   const form = Form.useFormInstance<FormData>();
-  const { action } = useFormContext();
+  const { action, resetCustomConfig } = useFormContext();
   const providerType = Form.useWatch(['config', 'type'], form);
   const { getRuleMessage } = useAppUtils();
 
@@ -40,6 +40,20 @@ const Basic: React.FC<{
       option?.value?.toLowerCase().includes(input.toLowerCase()) ||
       option?.description?.toLowerCase().includes(input.toLowerCase())
     );
+  };
+
+  // config fields (claudeCustomUrl, awsRegion, ...), credentials and models all
+  // belong to the provider they were entered for — carrying them over would
+  // submit one provider's models under another, and fire get-models / test-model
+  // against the new upstream with the previous provider's key
+  const handleProviderTypeChange = (value: string) => {
+    // setFieldValue replaces the value at the path; setFieldsValue would deep
+    // merge and leave the previous type's config fields behind
+    form.setFieldValue('config', { type: value });
+    form.setFieldValue('models', []);
+    form.setFieldValue('api_key', '');
+    form.setFieldValue('api_tokens', []);
+    resetCustomConfig?.();
   };
 
   const renderLogoPrefix = () => {
@@ -95,6 +109,7 @@ const Basic: React.FC<{
           prefix={renderLogoPrefix()}
           options={maasProviderOptions}
           optionRender={optionRender}
+          onChange={handleProviderTypeChange}
           label={intl.formatMessage({
             id: 'common.table.type'
           })}

--- a/src/pages/maas-provider/forms/index.tsx
+++ b/src/pages/maas-provider/forms/index.tsx
@@ -114,13 +114,30 @@ const ProviderForm: React.FC<ProviderFormProps> = forwardRef((props, ref) => {
     );
   };
 
+  // a cleared optional field means "unset" — the backend treats '' as an
+  // explicitly configured empty value, so send null instead
+  const normalizeConfig = (config: FormData['config']) => {
+    return _.mapValues(config, (value: any) => (value === '' ? null : value));
+  };
+
+  // the whole config, provider-specific fields included, so that get-models /
+  // test-model hit the upstream the user actually typed in the form
   const getCustomConfig = () => {
     const customConfig = yaml2Json(advanceRef.current?.getYamlValue() || '');
     const config = form.getFieldValue('config') || {};
     return {
-      ...config,
+      ...normalizeConfig(config),
       ...customConfig
     };
+  };
+
+  // in edit mode this YAML is generated, not hand-written: it holds whatever
+  // config keys the previous provider had beyond its own form fields. Those get
+  // spread back into config on submit, so switching provider type has to drop
+  // them along with the fields themselves.
+  const resetCustomConfig = () => {
+    form.setFieldValue('custom_config', '');
+    advanceRef.current?.setYamlValue?.('');
   };
 
   const handleOnFinish = (values: FormData) => {
@@ -128,7 +145,7 @@ const ProviderForm: React.FC<ProviderFormProps> = forwardRef((props, ref) => {
       ..._.omit(values, ['api_key']),
       api_tokens: formatAPIKeys(values),
       config: {
-        ...values.config,
+        ...normalizeConfig(values.config),
         ...yaml2Json(advanceRef.current?.getYamlValue() || '')
       },
       models: _.uniqBy(values.models, 'name'),
@@ -217,7 +234,8 @@ const ProviderForm: React.FC<ProviderFormProps> = forwardRef((props, ref) => {
           id: currentData?.id,
           currentData,
           providerFields,
-          getCustomConfig: getCustomConfig
+          getCustomConfig: getCustomConfig,
+          resetCustomConfig: resetCustomConfig
         }}
       >
         <Form

--- a/src/pages/maas-provider/forms/provider-configs.tsx
+++ b/src/pages/maas-provider/forms/provider-configs.tsx
@@ -22,6 +22,14 @@ const ProviderConfigs = () => {
       : undefined;
   };
 
+  const renderHint = (item: any) => {
+    return item.hint
+      ? item.hint.locale
+        ? intl.formatMessage({ id: item.hint.text })
+        : item.hint.text
+      : undefined;
+  };
+
   return (
     <>
       {providerFields && providerFields.length > 0
@@ -30,6 +38,7 @@ const ProviderConfigs = () => {
               <Form.Item
                 name={['config', item.name]}
                 rules={item.rules}
+                extra={renderHint(item)}
                 key={item.name}
               >
                 {item.type === 'Input' && (

--- a/src/pages/maas-provider/forms/supported-models.tsx
+++ b/src/pages/maas-provider/forms/supported-models.tsx
@@ -11,8 +11,12 @@ import ModelItem from './model-item';
 
 const SupportedModels = () => {
   const intl = useIntl();
-  const { providerModelList, loading, fetchProviderModels } =
-    useQueryProviderModels();
+  const {
+    providerModelList,
+    loading,
+    fetchProviderModels,
+    resetProviderModels
+  } = useQueryProviderModels();
   const form = Form.useFormInstance<FormData>();
   const modelList = Form.useWatch('models', form) || [];
   const prevConfigRef = useRef<{
@@ -72,6 +76,8 @@ const SupportedModels = () => {
           ...currentConfig
         };
 
+        // the options on screen still belong to the previous config
+        resetProviderModels();
         fetchProviderModels({
           id: generateID(),
           data: {
@@ -92,6 +98,7 @@ const SupportedModels = () => {
         api_key: ''
       };
       // If validation fails, reset the provider model list to avoid confusion
+      resetProviderModels();
     }
   };
 

--- a/src/pages/maas-provider/hooks/use-provider-required-fields.tsx
+++ b/src/pages/maas-provider/hooks/use-provider-required-fields.tsx
@@ -1,3 +1,4 @@
+import { isAbsoluteHttpUrl } from '@/utils';
 import { useAppUtils } from '@gpustack/core-ui';
 import { useIntl } from '@umijs/max';
 import { ProviderEnum } from '../config/providers';
@@ -6,6 +7,36 @@ import { RequiredFields } from '../config/types';
 const useProviderRequiredFields = () => {
   const intl = useIntl();
   const { getRuleMessage } = useAppUtils();
+
+  const validateCustomUrl = async (_: any, value: string) => {
+    if (!value || isAbsoluteHttpUrl(value)) {
+      return Promise.resolve();
+    }
+    return Promise.reject(
+      new Error(
+        intl.formatMessage({ id: 'providers.form.rules.absoluteHttpUrl' })
+      )
+    );
+  };
+
+  // openaiCustomUrl carries the extra requirement that claudeCustomUrl does not:
+  // the backend appends `/models` and `/chat/completions` to its path, so an
+  // address without one (`http://my-openai.com`) is rejected as invalid.
+  // Both conditions share one message, so that fixing what the example shows
+  // cannot land the user on a second example with different requirements.
+  const validateBaseUrl = async (_: any, value: string) => {
+    if (
+      !value ||
+      (isAbsoluteHttpUrl(value) && new URL(value).pathname.replace(/\/+$/, ''))
+    ) {
+      return Promise.resolve();
+    }
+    return Promise.reject(
+      new Error(
+        intl.formatMessage({ id: 'providers.form.rules.openaiCustomUrl' })
+      )
+    );
+  };
 
   const providerRequiredFieldsMap: Record<string, RequiredFields[]> = {
     [ProviderEnum.OPENAI]: [
@@ -17,7 +48,33 @@ const useProviderRequiredFields = () => {
         label: {
           text: 'providers.form.custombeckendUrl',
           locale: true
-        }
+        },
+        rules: [
+          {
+            validator: validateBaseUrl
+          }
+        ]
+      }
+    ],
+    [ProviderEnum.CLAUDE]: [
+      {
+        type: 'Input',
+        name: 'claudeCustomUrl',
+        placeholder: 'https://<your-anthropic-gateway>',
+        required: false,
+        label: {
+          text: 'providers.form.claudeCustomUrl',
+          locale: true
+        },
+        hint: {
+          text: 'providers.form.claudeCustomUrl.tips',
+          locale: true
+        },
+        rules: [
+          {
+            validator: validateCustomUrl
+          }
+        ]
       }
     ],
     [ProviderEnum.AZURE]: [

--- a/src/pages/maas-provider/hooks/use-query-provider-models.tsx
+++ b/src/pages/maas-provider/hooks/use-query-provider-models.tsx
@@ -60,6 +60,14 @@ export const useQueryProviderModels = () => {
     }
   );
 
+  // the list belongs to the provider it was fetched for — drop it, and any
+  // in-flight request that would repopulate it, once that provider is gone
+  const resetProviderModels = () => {
+    cancel();
+    axiosTokenRef.current?.cancel();
+    setProviderModelList([]);
+  };
+
   useEffect(() => {
     return () => {
       cancel();
@@ -70,7 +78,8 @@ export const useQueryProviderModels = () => {
   return {
     loading,
     providerModelList,
-    fetchProviderModels
+    fetchProviderModels,
+    resetProviderModels
   };
 };
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -14,6 +14,24 @@ export const isNotEmptyValueAllowNull = (value: any) => {
   return !!value || value === 0 || value === false || value === null;
 };
 
+/**
+ * An absolute http(s) URL with a host — the shape backends want for a custom
+ * upstream address. The scheme prefix is matched separately because `URL`
+ * accepts things this has to reject: `ftp://host` and `ws://host` both parse
+ * with a perfectly good hostname, and `http:/foo` is normalized into one.
+ * `host:8080` needs no help — `URL` reads it as a scheme and leaves no host.
+ */
+export const isAbsoluteHttpUrl = (value: string) => {
+  if (!/^https?:\/\//i.test(value)) {
+    return false;
+  }
+  try {
+    return !!new URL(value).hostname;
+  } catch {
+    return false;
+  }
+};
+
 export const handleBatchRequest = async (
   list: any[],
   fn: (args: any) => void


### PR DESCRIPTION
Refer to issue:
- https://github.com/gpustack/gpustack/issues/5314

Based on backend PR:
- https://github.com/gpustack/gpustack/pull/6075

Add an optional `config.claudeCustomUrl` field to the Claude provider form, pointing it at a self-hosted / proxied Anthropic-compatible upstream instead of api.anthropic.com. Validated as an absolute http(s) URL with a host, to match the backend rule that otherwise returns a 422. A hint below the field spells out the consequence: once set, the provider only speaks the Anthropic protocol (`/v1/messages`) and OpenAI-shaped requests are no longer converted.

### Not Claude-specific

Three of the fixes here apply to **every** provider, and are worth reviewing on their own terms:

- **Switching provider type now clears everything that belonged to the previous one** — config fields, `models`, `api_key` / `api_tokens`, the advanced YAML, and the fetched model catalog. Previously all of it carried over. The YAML case is the quiet one: in edit mode that YAML is generated rather than hand-written, so it held the old provider's leftover config keys and spread them back in on submit. Since the config schemas allow additional properties, those keys were written through silently instead of being rejected.
- **Cleared optional config fields submit `null` instead of `''`**, which the backend reads as an explicitly configured empty value.
- **`openaiCustomUrl` gets a validator**, which it had none of. Not the same one as `claudeCustomUrl`: the backend appends `/models` and `/chat/completions` to its path, so it additionally requires a non-empty path (`http://my-openai.com` is a 422, `http://my-openai.com/v1` is fine).

  This rule is not a schema constraint, so it does not appear in `/openapi.json` — it is an imperative check in `validate_provider` (`gpustack/routes/model_provider.py`), which runs on **both** create and update and has been in place since `1757d605` (2026-02-27).

  **QA note:** an existing OpenAI provider whose `openaiCustomUrl` has no path (e.g. `http://10.0.0.5:8000`) now fails inline when its edit drawer is submitted. This is not new validation — because `validate_provider` also runs on update, saving that provider already failed with a backend 422 carrying the same message. The change is that the failure is surfaced inline, before submit, and translated. Worth covering the "edit a pre-existing path-less provider" path explicitly.

`isAbsoluteHttpUrl` lives in `src/utils` rather than the page's config barrel, since it is a pure helper and not specific to one provider.
