### PR TITLE
feat(ui): serve correctly under a reverse-proxy subpath

### DIFF
--- a/config/config.ts
+++ b/config/config.ts
@@ -35,6 +35,27 @@ export default defineConfig({
     exclude: ['lodash', 'ml-pca', ...extraMfsuExclude]
   },
   base: process.env.npm_config_base || '/',
+  // `auto` makes every emitted asset URL resolve against the script that loads
+  // it instead of the origin root, which is what lets one build serve from any
+  // mount path — the UI ships as a prebuilt artifact, so a per-deployment
+  // rebuild is not an option. It covers the async chunks and both web workers
+  // (Monaco's, and the `new URL(..., import.meta.url)` embedding worker) for the
+  // same reason: all three go through the webpack runtime.
+  //
+  // Production only. The dev server always serves from the root, and `auto`
+  // there would put HMR and mfsu on a path they do not expect.
+  publicPath: isProduction ? 'auto' : '/',
+  // Assets referenced from CSS resolve against the *stylesheet's* URL, not the
+  // document's, and the production build puts every stylesheet one level down
+  // in `css/`. Umi's default of `./` therefore asks the browser for
+  // `/css/static/<font>` and gets a 404 — which is why Monaco's codicon icons
+  // and the whole KaTeX font set have been silently falling back. `../` climbs
+  // back out of `css/`, and stays correct under a subpath mount because it is
+  // still relative.
+  //
+  // Production only: the `css/` layout comes from the production chainWebpack
+  // below, so dev keeps umi's default.
+  cssPublicPath: isProduction ? '../' : './',
   ...(isProduction
     ? {
         jsMinifierOptions: {
@@ -66,7 +87,10 @@ export default defineConfig({
           monacoPluginConfig(config);
         }
       }),
-  favicons: ['/static/favicon.png'],
+  // Relative for the same reason as `publicPath`: a leading slash would send the
+  // browser to the origin root, which is the customer's own app when GPUStack is
+  // mounted under a subpath.
+  favicons: ['static/favicon.png'],
   jsMinifier: 'terser',
   cssMinifier: 'cssnano',
   presets: ['umi-presets-pro'],

--- a/plugin.ts
+++ b/plugin.ts
@@ -14,6 +14,36 @@ export default (api: IApi) => {
       env === 'production' ? info.version || info.commitId : `${info.commitId}`
     );
     if (env === 'production') {
+      // Umi writes the entry asset URLs root-absolute (`/js/umi.x.js`) whatever
+      // `publicPath` is set to, and a root-absolute URL resolves against the
+      // origin — which is the customer's own app when GPUStack is mounted under a
+      // subpath. Drop the leading slash so they resolve against the document
+      // instead, always the mount root because the router is `hash`.
+      //
+      // Only these first two assets need it: everything loaded later (async
+      // chunks, the Monaco and embedding workers) goes through the webpack
+      // runtime, which `publicPath: 'auto'` points at the entry script's own URL.
+      //
+      // Protocol-relative URLs (`//cdn.example.com/x.js`) also start with a
+      // slash and are left alone — stripping theirs would turn a host into a path.
+      const rootAbsolute = $('script[src], link[href]').filter((_index, el) => {
+        const url = $(el).attr('src') ?? $(el).attr('href') ?? '';
+        return url.startsWith('/') && !url.startsWith('//');
+      });
+      if (rootAbsolute.length === 0) {
+        throw new Error(
+          'modifyHTML: no root-absolute asset URL found to make relative. Umi ' +
+            'emits at least the entry script and stylesheet that way, so an ' +
+            'empty match means the markup changed shape — and a subpath ' +
+            'deployment would then silently fetch assets from the origin root.'
+        );
+      }
+      rootAbsolute.each((_index, el) => {
+        const $el = $(el);
+        const attr = $el.attr('src') != null ? 'src' : 'href';
+        $el.attr(attr, $el.attr(attr)!.slice(1));
+      });
+
       // Umi injects the entry bundle through addHTMLHeadScripts, so it lands in
       // <head> — before <div id="root"> exists, leaving the app nothing to mount
       // into. Move it to the end of <body>. `append` relocates the existing node,

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,7 +1,11 @@
 import { userSettingsHelperAtom } from '@/atoms/settings';
 import { GPUStackVersionAtom, UpdateCheckAtom, userAtom } from '@/atoms/user';
 import { setAtomStorage } from '@/atoms/utils';
-import { DEFAULT_ENTER_PAGE, GPUSTACK_API_BASE_URL } from '@/config/settings';
+import {
+  BASE_PATH,
+  DEFAULT_ENTER_PAGE,
+  GPUSTACK_API_BASE_URL
+} from '@/config/settings';
 import { COLOR_PRIMARY } from '@/config/theme/constants';
 import ErrorBoundary from '@/layouts/error-boundary';
 import { ensureCurrentLocaleMessages } from '@/locales/load-messages';
@@ -191,7 +195,7 @@ export async function getInitialState(): Promise<{
 }
 
 export const request: RequestConfig = {
-  baseURL: `/${GPUSTACK_API_BASE_URL}`,
+  baseURL: `${BASE_PATH}/${GPUSTACK_API_BASE_URL}`,
   ...requestConfig
 };
 

--- a/src/config/settings.ts
+++ b/src/config/settings.ts
@@ -7,6 +7,43 @@ export const DEFAULT_ENTER_PAGE = {
   login: '/login'
 };
 
+/**
+ * Mount path prefix, derived at runtime from the URL the browser actually
+ * loaded: `''` when served at the root, `/inner/gpustack` when a reverse proxy
+ * mounts GPUStack under a subpath.
+ *
+ * Derived rather than configured because the UI ships as a prebuilt artifact —
+ * the server serves `gpustack/ui/` exactly as downloaded — so there is no
+ * per-deployment build to bake a prefix into. One build has to work at any
+ * prefix.
+ *
+ * `pathname` is the whole prefix precisely because the router is `hash`: every
+ * in-app route lives after the `#`, so the path part never changes once the
+ * page has loaded. Moving to `history` routing would invalidate this and take
+ * subpath support with it.
+ *
+ * Deliberately the opposite choice from core-ui's storage namespace, which is a
+ * constant on purpose. The trade-off differs: a wrong prefix there silently
+ * switches the app onto a different set of persisted keys, while a wrong prefix
+ * here only makes requests 404 — a visible failure rather than silent state
+ * divergence.
+ */
+export const BASE_PATH =
+  typeof window === 'undefined'
+    ? ''
+    : window.location.pathname
+        .replace(/\/index\.html$/, '')
+        .replace(/\/+$/, '');
+
+/**
+ * Absolute, externally reachable root of this GPUStack — the browser's view of
+ * the server's `server_external_url`. For URLs *displayed* to the user to copy
+ * (OpenAI-compatible `base_url`, worker install commands), which have to be
+ * absolute. The app's own requests use `BASE_PATH` instead.
+ */
+export const EXTERNAL_BASE_URL =
+  typeof window === 'undefined' ? '' : `${window.location.origin}${BASE_PATH}`;
+
 export const GPUSTACK_API_BASE_URL = 'v2';
 export const OPENAI_COMPATIBLE = 'v1';
 

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -4,7 +4,11 @@ import DarkMask from '@/components/dark-mask';
 import '@/components/iconfont/iconfont.js';
 import PluginExtraFields from '@/components/plugin-extra-fields';
 import routeCachekey from '@/config/route-cachekey';
-import { DEFAULT_ENTER_PAGE, GPUSTACK_API_BASE_URL } from '@/config/settings';
+import {
+  BASE_PATH,
+  DEFAULT_ENTER_PAGE,
+  GPUSTACK_API_BASE_URL
+} from '@/config/settings';
 import { COLOR_PRIMARY } from '@/config/theme';
 import useCurrentUser from '@/hooks/use-current-user';
 import useTableFetch from '@/hooks/use-table-fetch';
@@ -361,7 +365,12 @@ export default (props: any) => {
       <App component={false}>
         <CoreUIProvider
           config={{
-            apiBaseUrl: GPUSTACK_API_BASE_URL,
+            // core-ui's raw-`fetch` hooks (LogsViewer, useDownloadStream) build
+            // their URL as `${apiBaseUrl}${url}` outside axios, so the mount
+            // prefix has to arrive here or log streaming reaches the origin root.
+            // Rooted rather than bare `v2`, which resolved against the document
+            // and so depended on the page URL keeping its trailing slash.
+            apiBaseUrl: `${BASE_PATH}/${GPUSTACK_API_BASE_URL}`,
             theme: userSettings.theme,
             iconUrl: '',
             isDarkTheme: userSettings.isDarkTheme,

--- a/src/pages/benchmark/services/use-export-benchmark.ts
+++ b/src/pages/benchmark/services/use-export-benchmark.ts
@@ -1,5 +1,6 @@
 import { GPUSTACK_API_BASE_URL } from '@/config/settings';
 import { downloadFile } from '@/utils/download-stream';
+import { withBasePath } from '@/utils/with-base-path';
 import { message } from 'antd';
 import dayjs from 'dayjs';
 import { EXPORT_BENCHMARK_LIST } from '../apis';
@@ -18,7 +19,7 @@ export function useExportBenchmark() {
     const fileName = `${name || 'benchmark'}_${date}`;
     try {
       const res = await fetch(
-        `${GPUSTACK_API_BASE_URL}${EXPORT_BENCHMARK_LIST}`,
+        withBasePath(`/${GPUSTACK_API_BASE_URL}${EXPORT_BENCHMARK_LIST}`),
         {
           method: 'POST',
           headers: {

--- a/src/pages/cluster-management/components/register-cluster-inner.tsx
+++ b/src/pages/cluster-management/components/register-cluster-inner.tsx
@@ -1,3 +1,4 @@
+import { EXTERNAL_BASE_URL } from '@/config/settings';
 import { HighlightCode } from '@gpustack/core-ui';
 import React, { useMemo } from 'react';
 import { generateK8sRegisterCommand } from '../config';
@@ -19,7 +20,9 @@ const AddCluster: React.FC<AddModalProps> = ({
 }) => {
   const code = useMemo(() => {
     return generateK8sRegisterCommand({
-      server: registrationInfo?.server_url || window.location.origin,
+      // Falls back to the browser's view of the server, prefix included, when the
+      // server has no `server_external_url` configured to hand us.
+      server: registrationInfo?.server_url || EXTERNAL_BASE_URL,
       clusterId: registrationInfo?.cluster_id,
       registrationToken: registrationInfo?.token,
       currentGPU,

--- a/src/pages/llmodels/apis/index.ts
+++ b/src/pages/llmodels/apis/index.ts
@@ -1,4 +1,5 @@
 import { ListItem as UserListItem } from '@/pages/users/config/types';
+import { withBasePath } from '@/utils/with-base-path';
 import { downloadFile, listFiles, listModels } from '@huggingface/hub';
 import { PipelineType } from '@huggingface/tasks';
 import { request } from '@umijs/max';
@@ -37,7 +38,8 @@ export const CATALOG_LIST_API = '/model-sets';
 export const MODEL_LORA_ADAPTER_API = '/models/adapters';
 
 const setProxyUrl = (url: string) => {
-  return `/proxy?url=${encodeURIComponent(url)}`;
+  // Consumed by raw `fetch` below, which gets no `baseURL` treatment.
+  return withBasePath(`/proxy?url=${encodeURIComponent(url)}`);
 };
 
 // ===================== Models =====================

--- a/src/pages/llmodels/apis/index.ts
+++ b/src/pages/llmodels/apis/index.ts
@@ -37,10 +37,16 @@ export const CATALOG_LIST_API = '/model-sets';
 
 export const MODEL_LORA_ADAPTER_API = '/models/adapters';
 
-const setProxyUrl = (url: string) => {
-  // Consumed by raw `fetch` below, which gets no `baseURL` treatment.
-  return withBasePath(`/proxy?url=${encodeURIComponent(url)}`);
-};
+// Two spellings of the same endpoint, because the two clients used below
+// disagree about who owns the mount prefix. Picking the wrong one is invisible
+// at the root — where the prefix is empty — and 404s under a subpath, so the
+// names carry the distinction instead of a comment at each call site.
+
+/** For `request`: the axios layer prepends the mount prefix via `baseURL`. */
+const proxyPath = (url: string) => `/proxy?url=${encodeURIComponent(url)}`;
+
+/** For raw `fetch`, which gets no `baseURL` treatment and needs the prefix. */
+const proxyFetchUrl = (url: string) => withBasePath(proxyPath(url));
 
 // ===================== Models =====================
 
@@ -191,7 +197,7 @@ export async function queryHuggingfaceModelDetail(
   options?: any
 ) {
   const url = `https://huggingface.co/api/models/${params.repo}`;
-  return request(setProxyUrl(url), {
+  return request(proxyPath(url), {
     method: 'GET',
     cancelToken: options?.token
   });
@@ -224,7 +230,7 @@ export async function queryModelScopeModels(
         }
       : {};
 
-  const res = await fetch(setProxyUrl(`${MODEL_SCOPE_LIST_MODEL_API}`), {
+  const res = await fetch(proxyFetchUrl(`${MODEL_SCOPE_LIST_MODEL_API}`), {
     method: 'PUT',
     signal: config?.signal,
     headers: {
@@ -248,7 +254,7 @@ export async function queryModelScopeModelDetail(
   params: { name: string },
   options?: any
 ) {
-  return request(setProxyUrl(`${MODE_SCOPE_MODEL_FIELS_API}${params.name}`), {
+  return request(proxyPath(`${MODE_SCOPE_MODEL_FIELS_API}${params.name}`), {
     method: 'GET',
     cancelToken: options?.token
   });
@@ -265,7 +271,7 @@ export async function queryModelScopeModelFiles(
       Root: ''
     }
   )}`;
-  const res = await fetch(setProxyUrl(url), {
+  const res = await fetch(proxyFetchUrl(url), {
     method: 'GET',
     signal: options?.signal,
     body: null
@@ -303,7 +309,7 @@ export async function queryHuggingfaceModels(
         ? `${_url}&sort=${params.search.sort}`
         : _url;
       try {
-        return fetch(setProxyUrl(url), {
+        return fetch(proxyFetchUrl(url), {
           ...config,
           signal: options.signal
         });
@@ -329,7 +335,7 @@ export async function queryHuggingfaceModelFiles(
     recursive: true,
     fetch(url: string, config: any) {
       try {
-        return fetch(setProxyUrl(url), {
+        return fetch(proxyFetchUrl(url), {
           ...config,
           signal: options?.signal
         });
@@ -355,7 +361,7 @@ export async function downloadModelFile(
       revision: revision,
       path: path,
       fetch(url: string, config: any) {
-        return fetch(setProxyUrl(url), {
+        return fetch(proxyFetchUrl(url), {
           ...config,
           signal: options?.signal
         });
@@ -369,7 +375,7 @@ export async function downloadModelScopeModelfile(
   options?: any
 ) {
   const url = `${MODE_SCOPE_MODEL_FIELS_API}${params.name}/resolve/master/config.json`;
-  const res = await fetch(setProxyUrl(url), {
+  const res = await fetch(proxyFetchUrl(url), {
     method: 'GET',
     signal: options?.signal
   });

--- a/src/pages/llmodels/components/api-access-info.tsx
+++ b/src/pages/llmodels/components/api-access-info.tsx
@@ -1,4 +1,4 @@
-import { OPENAI_COMPATIBLE } from '@/config/settings';
+import { EXTERNAL_BASE_URL, OPENAI_COMPATIBLE } from '@/config/settings';
 import {
   AUDIO_SPEECH_TO_TEXT_API,
   AUDIO_TEXT_TO_SPEECH_API,
@@ -100,9 +100,9 @@ const ApiAccessInfo = ({ open, data, onClose }: ApiAccessInfoProps) => {
 
   const endPoint = useMemo(() => {
     if (!data.generic_proxy) {
-      return `${window.location.origin}/${OPENAI_COMPATIBLE}`;
+      return `${EXTERNAL_BASE_URL}/${OPENAI_COMPATIBLE}`;
     }
-    return `${window.location.origin}${MODEL_PROXY}/${data.id}/<YOUR_API_PATH>`;
+    return `${EXTERNAL_BASE_URL}${MODEL_PROXY}/${data.id}/<YOUR_API_PATH>`;
   }, [data]);
 
   const isRanker = useMemo(() => {

--- a/src/pages/llmodels/forms/basic.tsx
+++ b/src/pages/llmodels/forms/basic.tsx
@@ -1,6 +1,6 @@
 import PluginExtraFields from '@/components/plugin-extra-fields';
 import { modelNameReg, PageAction } from '@/config';
-import { OPENAI_COMPATIBLE } from '@/config/settings';
+import { EXTERNAL_BASE_URL, OPENAI_COMPATIBLE } from '@/config/settings';
 import {
   ClusterStatusLabelMap,
   ClusterStatusValueMap
@@ -280,7 +280,7 @@ const BasicForm: React.FC<BasicFormProps> = (props) => {
           required
           description={intl.formatMessage(
             { id: 'models.form.replicas.tips' },
-            { api: `${window.location.origin}/${OPENAI_COMPATIBLE}` }
+            { api: `${EXTERNAL_BASE_URL}/${OPENAI_COMPATIBLE}` }
           )}
           min={0}
         ></CInput.Number>

--- a/src/pages/llmodels/hooks/use-models-columns.tsx
+++ b/src/pages/llmodels/hooks/use-models-columns.tsx
@@ -1,6 +1,10 @@
 // columns.ts
 import { systemConfigAtom } from '@/atoms/system';
-import { OPENAI_COMPATIBLE, tableSorter } from '@/config/settings';
+import {
+  EXTERNAL_BASE_URL,
+  OPENAI_COMPATIBLE,
+  tableSorter
+} from '@/config/settings';
 import { TargetStatusValueMap } from '@/pages/model-routes/config';
 import { usePluginListColumns } from '@/plugins/list-extra-columns';
 import { QuestionCircleOutlined } from '@ant-design/icons';
@@ -232,7 +236,7 @@ const useModelsColumns = ({
           <Tooltip
             title={intl.formatMessage(
               { id: 'models.form.replicas.tips' },
-              { api: `${window.location.origin}/${OPENAI_COMPATIBLE}` }
+              { api: `${EXTERNAL_BASE_URL}/${OPENAI_COMPATIBLE}` }
             )}
           >
             <span>{intl.formatMessage({ id: 'models.form.replicas' })}</span>

--- a/src/pages/login/components/login-form.tsx
+++ b/src/pages/login/components/login-form.tsx
@@ -1,6 +1,6 @@
 import LogoIcon from '@/assets/images/gpustack-logo.png';
 import { userAtom } from '@/atoms/user';
-import { history, useIntl, useModel } from '@umijs/max';
+import { useIntl, useModel } from '@umijs/max';
 import { Button, Divider, Form, Spin, message } from 'antd';
 import { createStyles } from 'antd-style';
 import { useAtom } from 'jotai';
@@ -156,8 +156,8 @@ const LoginForm = () => {
   // through the existing toast, and clear the param from the URL so
   // a refresh doesn't re-fire the toast.
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const errorCode = params.get('error');
+    const url = new URL(window.location.href);
+    const errorCode = url.searchParams.get('error');
     if (!errorCode) return;
     // Codes recognised by the backend's SSO callback wrapper. Map to
     // an i18n key per code; an unknown code is silently ignored so a
@@ -170,16 +170,15 @@ const LoginForm = () => {
     if (messageId) {
       handleOnError(new Error(intl.formatMessage({ id: messageId })));
     }
-    params.delete('error');
-    const newQuery = params.toString();
-    // Route through ``@umijs/max``'s ``history`` rather than
-    // ``window.history.replaceState`` so the router's internal
-    // location stays in sync with the address bar — any other code
-    // that reads it (route guards, ``useLocation``, …) sees the
-    // cleaned URL on the same render.
-    history.replace(
-      window.location.pathname + (newQuery ? `?${newQuery}` : '')
-    );
+    // Clear the param through the *browser's* history, not the router's.
+    // The router is hash-based, so its ``history`` owns only the fragment:
+    // it cannot reach the real query string the param lives in, and handing
+    // it a pathname would set the fragment to that value — navigating away
+    // from ``/login`` and unmounting this component, whose ``contextHolder``
+    // the toast above needs in order to render. Keeping the whole ``URL``
+    // preserves the ``#/login`` fragment untouched.
+    url.searchParams.delete('error');
+    window.history.replaceState(null, '', url.toString());
   }, []);
 
   // local user authentication

--- a/src/pages/login/hooks/use-sso-auth.ts
+++ b/src/pages/login/hooks/use-sso-auth.ts
@@ -1,4 +1,5 @@
 // hooks/useSSOAuth.ts
+import { withBasePath } from '@/utils/with-base-path';
 import { history, useIntl } from '@umijs/max';
 import { useEffect, useState } from 'react';
 import { ExternalAuth, fetchAuthConfig } from '../apis';
@@ -37,7 +38,11 @@ export function useSSOAuth({
 
   const loginWithExternalAuth = (auth: ExternalAuth | null) => {
     if (auth) {
-      window.location.href = auth.login_url;
+      // The server hands back an app-relative path (`/auth/oidc/login`) — it
+      // has no idea what prefix it is mounted under, so navigating to it
+      // verbatim would leave for the origin root. An absolute URL, should the
+      // server ever return one, passes through untouched.
+      window.location.href = withBasePath(auth.login_url);
     }
   };
 

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -6,7 +6,7 @@ import Footer from '@/components/footer';
 import LangSelect from '@/components/lang-select';
 import ThemeDropActions from '@/components/theme-toggle/theme-drop-actions';
 import { PasswordReg } from '@/config';
-import { GPUSTACK_API_BASE_URL } from '@/config/settings';
+import { BASE_PATH, GPUSTACK_API_BASE_URL } from '@/config/settings';
 import { COLOR_PRIMARY } from '@/config/theme/constants';
 import externalLinks from '@/constants/external-links';
 import useUserSettings from '@/hooks/use-user-settings';
@@ -211,7 +211,7 @@ const Login = () => {
     >
       <CoreUIProvider
         config={{
-          apiBaseUrl: GPUSTACK_API_BASE_URL,
+          apiBaseUrl: `${BASE_PATH}/${GPUSTACK_API_BASE_URL}`,
           theme: userSettings.theme,
           iconUrl: '',
           isDarkTheme: userSettings.isDarkTheme,

--- a/src/pages/playground/apis/index.ts
+++ b/src/pages/playground/apis/index.ts
@@ -1,5 +1,6 @@
 import { GPUSTACK_API_BASE_URL, OPENAI_COMPATIBLE } from '@/config/settings';
 import { createFormData, errorHandler } from '@/utils/fetch-chunk-data';
+import { withBasePath } from '@/utils/with-base-path';
 import { request } from '@umijs/max';
 
 export { GPUSTACK_API_BASE_URL, OPENAI_COMPATIBLE };
@@ -87,7 +88,7 @@ export const createImages = async (
   },
   options?: any
 ) => {
-  const res = await fetch(`${CREAT_IMAGE_API}`, {
+  const res = await fetch(withBasePath(CREAT_IMAGE_API), {
     method: 'POST',
     body: JSON.stringify(params),
     signal: options.signal,
@@ -109,7 +110,7 @@ export const editImage = async (params: {
   data?: any;
   signal?: AbortSignal;
 }) => {
-  const response = await fetch(EDIT_IMAGE_API, {
+  const response = await fetch(withBasePath(EDIT_IMAGE_API), {
     method: 'POST',
     body: createFormData(params.data),
     signal: params.signal
@@ -124,7 +125,7 @@ export const createImage = async (params: {
   data?: any;
   signal?: AbortSignal;
 }) => {
-  const response = await fetch(CREAT_IMAGE_API, {
+  const response = await fetch(withBasePath(CREAT_IMAGE_API), {
     method: 'POST',
     body: JSON.stringify(params.data),
     signal: params.signal,
@@ -152,7 +153,7 @@ export const createVideo = async (params: { data?: any; token?: any }) => {
 
 // ============ audio ============
 export const textToSpeech = async (params: any, options?: any) => {
-  const res = await fetch(AUDIO_TEXT_TO_SPEECH_API, {
+  const res = await fetch(withBasePath(AUDIO_TEXT_TO_SPEECH_API), {
     method: 'POST',
     body: JSON.stringify(params.data),
     headers: {

--- a/src/pages/playground/view-code/audio.ts
+++ b/src/pages/playground/view-code/audio.ts
@@ -1,3 +1,4 @@
+import { EXTERNAL_BASE_URL } from '@/config/settings';
 import _ from 'lodash';
 import { MODEL_PROXY, OPENAI_COMPATIBLE } from '../apis';
 import { fomatNodeJsParams, formatCurlArgs, formatPyParams } from './utils';
@@ -8,7 +9,7 @@ export const generateSpeechToTextCurlCode = ({
   routeID,
   parameters
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
   // replace url OPENAI_COMPATIBLE with GPUSTACK
   const api = modelProxy ? `${MODEL_PROXY}/${routeID}/\${YOUR_API_PATH}` : url;
 
@@ -30,7 +31,7 @@ export const speechToTextCode = ({
   api: url,
   parameters
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
 
   // ========================= Curl =========================
   const curlCode = generateSpeechToTextCurlCode({ api: url, parameters });
@@ -89,7 +90,7 @@ export const generateTextToSpeechCurlCode = ({
   routeID,
   parameters
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
   const api = modelProxy ? `${MODEL_PROXY}/${routeID}/\${YOUR_API_PATH}` : url;
 
   // ========================= Curl =========================
@@ -106,7 +107,7 @@ export const TextToSpeechCode = ({
   api: url,
   parameters
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
 
   // ========================= Curl =========================
   const curlCode = generateTextToSpeechCurlCode({ api: url, parameters });

--- a/src/pages/playground/view-code/embedding.ts
+++ b/src/pages/playground/view-code/embedding.ts
@@ -1,3 +1,4 @@
+import { EXTERNAL_BASE_URL } from '@/config/settings';
 import { MODEL_PROXY, OPENAI_COMPATIBLE } from '../apis';
 import { fomatNodeJsParams, formatCurlArgs, formatPyParams } from './utils';
 
@@ -7,7 +8,7 @@ export const generateEmbeddingCurlCode = ({
   routeID,
   parameters
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
   const api = modelProxy ? `${MODEL_PROXY}/${routeID}/\${YOUR_API_PATH}` : url;
 
   // ========================= Curl =========================
@@ -24,7 +25,7 @@ export const generateEmbeddingCode = ({
   api: url,
   parameters
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
 
   // ========================= Curl =========================
   const curlCode = generateEmbeddingCurlCode({ api: url, parameters });

--- a/src/pages/playground/view-code/image.ts
+++ b/src/pages/playground/view-code/image.ts
@@ -1,3 +1,4 @@
+import { EXTERNAL_BASE_URL } from '@/config/settings';
 import _ from 'lodash';
 import { MODEL_PROXY, OPENAI_COMPATIBLE } from '../apis';
 import { fomatNodeJsParams, formatCurlArgs, formatPyParams } from './utils';
@@ -10,7 +11,7 @@ export const generateImageCurlCode = ({
   isFormdata = false,
   edit = false
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
   const api = modelProxy ? `${MODEL_PROXY}/${routeID}/\${YOUR_API_PATH}` : url;
 
   // ========================= Curl =========================
@@ -41,7 +42,7 @@ export const generateImageCode = ({
   isFormdata = false,
   edit = false
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
   const api = url;
 
   // ========================= Curl =========================
@@ -110,7 +111,7 @@ export const generateOpenaiImageCode = ({
   isFormdata = false,
   edit = false
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
   const api = url;
 
   // ========================= Curl =========================

--- a/src/pages/playground/view-code/llm.ts
+++ b/src/pages/playground/view-code/llm.ts
@@ -1,3 +1,4 @@
+import { EXTERNAL_BASE_URL } from '@/config/settings';
 import { MODEL_PROXY, OPENAI_COMPATIBLE } from '../apis';
 import { fomatNodeJsParams, formatCurlArgs, formatPyParams } from './utils';
 
@@ -7,7 +8,7 @@ export const generateLLmCurlCode = ({
   routeID,
   parameters
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
   const api = modelProxy ? `${MODEL_PROXY}/${routeID}/\${YOUR_API_PATH}` : url;
 
   // ========================= Curl =========================
@@ -24,7 +25,7 @@ export const generateLLMCode = ({
   api: url,
   parameters
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
 
   // ========================= Curl =========================
   const curlCode = generateLLmCurlCode({ api: url, parameters });

--- a/src/pages/playground/view-code/rerank.ts
+++ b/src/pages/playground/view-code/rerank.ts
@@ -1,3 +1,4 @@
+import { EXTERNAL_BASE_URL } from '@/config/settings';
 import { MODEL_PROXY } from '../apis';
 import { formatCurlArgs } from './utils';
 
@@ -7,7 +8,7 @@ export const generateRerankCurlCode = ({
   routeID,
   parameters
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
   const apiUrl = modelProxy
     ? `${MODEL_PROXY}/${routeID}/\${YOUR_API_PATH}`
     : api;
@@ -26,7 +27,7 @@ export const generateRerankCode = ({
   api,
   parameters
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
 
   // ========================= Curl =========================
   const curlCode = generateRerankCurlCode({ api, parameters });

--- a/src/pages/playground/view-code/video.ts
+++ b/src/pages/playground/view-code/video.ts
@@ -1,3 +1,4 @@
+import { EXTERNAL_BASE_URL } from '@/config/settings';
 import _ from 'lodash';
 import { MODEL_PROXY, OPENAI_COMPATIBLE } from '../apis';
 import { fomatNodeJsParams, formatCurlArgs, formatPyParams } from './utils';
@@ -10,7 +11,7 @@ export const generateCurlCode = ({
   isFormdata = false,
   edit = false
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
   const api = modelProxy ? `${MODEL_PROXY}/${routeID}/\${YOUR_API_PATH}` : url;
 
   // ========================= Curl =========================
@@ -31,7 +32,7 @@ export const generateCode = ({
   parameters,
   isFormdata = false
 }: Record<string, any>) => {
-  const host = window.location.origin;
+  const host = EXTERNAL_BASE_URL;
   const api = url;
 
   // ========================= Curl =========================

--- a/src/pages/resources/apis/index.ts
+++ b/src/pages/resources/apis/index.ts
@@ -1,5 +1,6 @@
 import { GPUSTACK_API_BASE_URL } from '@/config/settings';
 import { downloadFile } from '@/utils/download-stream';
+import { withBasePath } from '@/utils/with-base-path';
 import { request } from '@umijs/max';
 import { message } from 'antd';
 import { GPUDeviceItem, ListItem, ModelFile } from '../config/types';
@@ -26,7 +27,7 @@ export async function downloadWorkerPrivateKey({
 }) {
   try {
     const res = await fetch(
-      `/${GPUSTACK_API_BASE_URL}${WORKERS_API}/${id}/privatekey`
+      withBasePath(`/${GPUSTACK_API_BASE_URL}${WORKERS_API}/${id}/privatekey`)
     );
     // header
     const contentDispostion = res.headers.get('content-Disposition');

--- a/src/pages/resources/components/script-install.tsx
+++ b/src/pages/resources/components/script-install.tsx
@@ -1,3 +1,4 @@
+import { EXTERNAL_BASE_URL } from '@/config/settings';
 import { HighlightCode } from '@gpustack/core-ui';
 import { useIntl } from '@umijs/max';
 import React, { useMemo } from 'react';
@@ -8,7 +9,11 @@ type ViewModalProps = { token: string };
 const AddWorker: React.FC<ViewModalProps> = (props) => {
   const intl = useIntl();
 
-  const origin = window.location.origin;
+  // The address the worker will dial, so it has to be one that actually reaches
+  // the server: under a subpath mount that includes the prefix. Note this puts
+  // worker traffic through the same reverse proxy as the UI, which therefore has
+  // to forward the WebSocket upgrade the browser itself never needs.
+  const serverUrl = EXTERNAL_BASE_URL;
 
   const labels = useMemo(
     () => ({
@@ -49,7 +54,7 @@ const AddWorker: React.FC<ViewModalProps> = (props) => {
       <h4 className="font-size-13">{labels.linuxOrMac}</h4>
       <HighlightCode
         code={addWorkerGuide.mac.registerWorker({
-          server: origin,
+          server: serverUrl,
           token: '${token}'
         })}
         theme="dark"
@@ -58,7 +63,7 @@ const AddWorker: React.FC<ViewModalProps> = (props) => {
       <HighlightCode
         theme="dark"
         code={addWorkerGuide.win.registerWorker({
-          server: origin,
+          server: serverUrl,
           token: '${token}'
         })}
       ></HighlightCode>

--- a/src/request-config.tsx
+++ b/src/request-config.tsx
@@ -2,15 +2,16 @@ import { userAtom } from '@/atoms/user';
 import { clearAtomStorage } from '@/atoms/utils';
 import { history, RequestConfig } from '@umijs/max';
 import { message } from 'antd';
-import { DEFAULT_ENTER_PAGE } from './config/settings';
+import { BASE_PATH, DEFAULT_ENTER_PAGE } from './config/settings';
 import ErrorMessageContent from './pages/_components/error-message-content';
 import {
   extraRequestInterceptors,
   extraResponseInterceptors
 } from './request.extensions';
 
-//  these APIs do not via the GPUSTACK_API_BASE_URL
-const NoBaseURLAPIs = ['/auth', '/v1', '/version', '/proxy', '/update'];
+// These APIs sit outside the versioned management API, so they carry the mount
+// prefix on its own rather than the default `${BASE_PATH}/${GPUSTACK_API_BASE_URL}`.
+const UnversionedAPIs = ['/auth', '/v1', '/version', '/proxy', '/update'];
 
 export const requestConfig: RequestConfig = {
   errorConfig: {
@@ -38,8 +39,8 @@ export const requestConfig: RequestConfig = {
   },
   requestInterceptors: [
     (url, options) => {
-      if (NoBaseURLAPIs.some((api) => url.startsWith(api))) {
-        options.baseURL = '';
+      if (UnversionedAPIs.some((api) => url.startsWith(api))) {
+        options.baseURL = BASE_PATH;
         return { url, options };
       }
       return { url, options };

--- a/src/utils/fetch-chunk-data.ts
+++ b/src/utils/fetch-chunk-data.ts
@@ -1,3 +1,4 @@
+import { withBasePath } from '@/utils/with-base-path';
 import { throttle } from 'lodash';
 import qs from 'query-string';
 
@@ -65,7 +66,7 @@ export const fetchChunkedData = async (params: {
   if (params.params) {
     url = `${url}?${qs.stringify(params.params)}`;
   }
-  const response = await fetch(url, {
+  const response = await fetch(withBasePath(url), {
     method,
     body: method === 'POST' ? JSON.stringify(params.data) : null,
     signal: params.signal,
@@ -119,7 +120,7 @@ export const fetchChunkedDataPostFormData = async (params: {
   headers?: any;
 }) => {
   const { url } = params;
-  const response = await fetch(url, {
+  const response = await fetch(withBasePath(url), {
     method: 'POST',
     body: createFormData(params.data),
     signal: params.signal,

--- a/src/utils/with-base-path.ts
+++ b/src/utils/with-base-path.ts
@@ -1,0 +1,22 @@
+import { BASE_PATH } from '@/config/settings';
+
+/**
+ * Prefix an app-relative request path with the mount prefix.
+ *
+ * Only for requests issued through raw `fetch` — streaming bodies, blob
+ * downloads and form posts that need a `Response` the app's axios instance
+ * does not hand back. Axios applies `BASE_PATH` through its own `baseURL`, so
+ * routing an already-prefixed URL through here would double the prefix.
+ *
+ * An absolute (`https://host/x`) or protocol-relative (`//host/x`) URL names
+ * its own host and is returned untouched. So is a path with no leading slash,
+ * which the browser already resolves against the document — but prefer passing
+ * a rooted path, since document-relative resolution silently depends on the
+ * page URL keeping its trailing slash.
+ */
+export const withBasePath = (url: string): string => {
+  if (!url.startsWith('/') || url.startsWith('//')) {
+    return url;
+  }
+  return `${BASE_PATH}${url}`;
+};


### PR DESCRIPTION
Groundwork for gpustack/gpustack#5270 — mounting GPUStack under a customer's
reverse-proxy subpath, e.g. `http://customer/inner/gpustack/`.

## Approach

nginx strips the prefix, so the backend keeps seeing the same paths it does at
the root and stays agnostic to where it is mounted. The frontend derives the
prefix at **runtime** from `window.location.pathname` and applies it to every
URL it builds.

Runtime derivation is exact here because **the router is hash-based** — all app
routes live in the fragment, so `pathname` is always the mount prefix and
nothing else. That is what makes this work with zero configuration: one
prebuilt artifact serves any prefix, which matters because the UI ships as a
downloaded artifact and a per-deployment rebuild is not an option.

The acceptance criterion is that a customer needs **one** nginx `location`
block. Needing a second for `/js`, `/v2`, `/auth`, … would mean the frontend is
still emitting root-absolute URLs. That criterion is the reporter's own: the
issue's "current workaround" is a list of five extra `location` blocks.

## What changed

- `src/config/settings.ts` — `BASE_PATH` / `EXTERNAL_BASE_URL` derived at runtime
- `src/utils/with-base-path.ts` — prefixes root-absolute paths, passes absolute
  and protocol-relative URLs through untouched
- axios `baseURL` and the two `CoreUIProvider` `apiBaseUrl` sites
- 11 raw-`fetch` call sites across 5 files (streaming, blob download, form post
  — the paths that need a `Response` axios does not hand back)
- Display URLs shown to users (install scripts, view-code panels) use
  `EXTERNAL_BASE_URL`
- `publicPath: 'auto'` so async chunks and both web workers resolve against the
  entry script instead of the origin root
- `plugin.ts` makes the two entry asset URLs document-relative — umi writes them
  root-absolute whatever `publicPath` says. Guarded by a `throw` so a future umi
  change fails the build instead of silently producing a broken artifact.

## Root-path behaviour

At the root `BASE_PATH` is `''`, so every URL change above is an identity
operation. Two things are worth a reviewer's attention:

**`cssPublicPath: '../'` is a fix that lands at the root too.** Assets
referenced from CSS resolve against the *stylesheet's* URL, and production puts
stylesheets in `css/`. Umi's default `'./'` therefore requested
`/css/static/<font>` and 404'd — Monaco's codicon icons and the whole KaTeX
font set have been silently falling back. Expect those to start rendering;
visual-regression baselines will show diffs. Verified `dist/css/` holds only
`.css` files, so nothing depended on the old resolution.

**The document-relative entry URLs depend on the document URL.** Safe because
the server returns `index.html` from exactly one route (`GET /`) with no SPA
catch-all and no 404 fallback, so the document URL is always `/`. This is a
consequence of hash routing — the backend never needs a catch-all.

`publicPath` and `cssPublicPath` are both production-only; the dev server is
untouched.

## Two follow-up commits

**`fix(llmodels)` — a defect in this PR's first commit, caught in review.**
`setProxyUrl` applied `withBasePath` unconditionally, but two of its eight
callers go through axios, which adds the prefix again via `baseURL` — producing
`/inner/gpustack/v2/inner/gpustack/proxy?url=…`. Split by consumer
(`proxyPath` for axios, `proxyFetchUrl` for raw `fetch`) so the call site picks
the right one and the interceptor stays unchanged. Root path was unaffected
because the prefix is empty there, which is also why the subpath run missed it:
`/proxy` only fires once you open a model's detail view, so it was not among
the requests exercised. Audited the other nine `withBasePath` call sites — all
genuinely raw `fetch` or full-page navigation.

**`fix(login)` — a pre-existing bug, same class as `cssPublicPath`.** The SSO
failure toast never rendered, at the root either. The router is hash-based, so
its `history` owns only the fragment: it could not reach the query string
`?error=` lives in, and handing it a pathname set the fragment instead —
navigating away from `/login` and unmounting the component whose
`contextHolder` the toast needs. Now cleared through the browser's history with
the fragment preserved. This completes the chain that gpustack/gpustack#6082
opens on the backend side; before, only half of it worked.

## Verification

Ran the real server with this build, at the root and behind nginx at
`/inner/gpustack/`, plus a negative control (the pre-change artifact, which
fails as expected).

Under the subpath: `location.pathname` is `/inner/gpustack/`, all 85 requests
land under `/inner`, Monaco starts 2 workers and tokenises, the codicon font
returns 200, inference returns a 503 from the backend rather than a 404 from
nginx, and there are no page errors.

The SSO toast was checked separately at both mount points — the message
renders, `?error=` is cleared from `location.search`, and the route stays on
`#/login`.

## What this does not do

**Subpath mounting is not yet usable end to end** — the backend still needs
`root_path` for `/docs` + `/openapi.json`, which are the last two entries on
the reporter's workaround list. Please don't announce subpath support on this
PR alone.

Not covered by the runtime verification: the log viewer needs a worker to
exercise (its `apiBaseUrl` value is unchanged at the root, but there is no
runtime evidence), and only the SSO *failure* callback was exercised.