### PR TITLE
feat(source): manage where catalog and backend content comes from

### DIFF
--- a/src/locales/en-US/backends.ts
+++ b/src/locales/en-US/backends.ts
@@ -58,10 +58,10 @@ export default {
     'To use a different version of a built-in backend (e.g., vLLM, SGLang, MindIE), please add a new version to the existing backend instead of adding a custom backend.',
   // Backend source configuration (built-in backend versions + community library)
   'backend.source.title': 'Backend Source',
-  'backend.source.builtin.title': 'Built-in backend source',
+  'backend.source.builtin.title': 'Built-in Backend',
   'backend.source.builtin.official':
     'Follows the image versions GPUStack publishes for the built-in backends (vLLM, SGLang, MindIE, VoxBox).',
-  'backend.source.community.title': 'Community backend source',
+  'backend.source.community.title': 'Community Backend',
   'backend.source.community.official':
     'Follows the community backend list GPUStack publishes, on top of the one packaged with this release.'
 };

--- a/src/locales/en-US/backends.ts
+++ b/src/locales/en-US/backends.ts
@@ -55,5 +55,13 @@ export default {
   'backend.add.community': 'Community',
   'backend.community.title': 'Community Backend Marketplace',
   'backend.form.add.hint':
-    'To use a different version of a built-in backend (e.g., vLLM, SGLang, MindIE), please add a new version to the existing backend instead of adding a custom backend.'
+    'To use a different version of a built-in backend (e.g., vLLM, SGLang, MindIE), please add a new version to the existing backend instead of adding a custom backend.',
+  // Backend source configuration (built-in backend versions + community library)
+  'backend.source.title': 'Backend Source',
+  'backend.source.builtin.title': 'Built-in backend source',
+  'backend.source.builtin.official':
+    'Follows the image versions GPUStack publishes for the built-in backends (vLLM, SGLang, MindIE, VoxBox).',
+  'backend.source.community.title': 'Community backend source',
+  'backend.source.community.official':
+    'Follows the community backend list GPUStack publishes, on top of the one packaged with this release.'
 };

--- a/src/locales/en-US/common.ts
+++ b/src/locales/en-US/common.ts
@@ -313,5 +313,48 @@ export default {
   'common.max': 'Max {count}',
   'common.max.count': '{label} Count',
   'common.validate.group': 'Please complete the {group} configuration',
-  'common.preferences': 'Preferences'
+  'common.preferences': 'Preferences',
+  // Shared by the source config drawer (src/pages/_components/source-config)
+  'common.source.manage': 'Manage Sources',
+  'common.source.type.builtin': 'Embedded',
+  'common.source.type.builtin.desc':
+    'Serves only what this release was packaged with, with no network access.',
+  'common.source.type.url': 'URL',
+  'common.source.type.url.desc': 'Fetched by the server, can auto-update.',
+  'common.source.type.file': 'Yaml File',
+  'common.source.type.file.desc':
+    'Paste the content directly; never auto-updates.',
+  'common.source.url': 'Source URL',
+  'common.source.url.scheme': 'The URL must start with http:// or https://',
+  'common.source.url.credentials': 'The URL must not embed credentials',
+  'common.source.url.host': 'The URL must include a host',
+  'common.source.content': 'Content',
+  'common.source.content.hint':
+    'Paste the YAML here, or import a file to load it into the editor. Only this text is sent — the server keeps no file.',
+  'common.source.save': 'Save',
+  'common.source.sync.unchanged': 'The remote content has not changed.',
+  'common.source.lastSync': 'Content taken at {time}',
+  'common.source.tag.custom': 'Custom',
+  'common.source.tag.official': 'Official',
+  'common.source.empty.hint':
+    'Your own URL replaces the official source entirely.',
+  'common.source.empty.hint.file':
+    'Leave the content empty to follow the official source — {description}',
+  'common.source.reset': 'Reset to Official Source',
+  'common.source.reset.tip':
+    'Follow the official source again, applied when you save — {description}',
+  'common.source.autoUpdate': 'Auto-update',
+  'common.source.autoUpdate.interval': 'Update Interval (hours)',
+  'common.source.autoUpdate.official.tip':
+    'How often to check the official OTA server for new content. Off leaves the stored content in place until you sync it yourself.',
+  'common.source.autoUpdate.custom.tip':
+    'How often to re-fetch your URL. Off leaves your source untouched until you save or reload it.',
+  'common.source.lastUpdated': 'Last updated {time}',
+  'common.source.official.link': 'Official File',
+  'common.source.sync.official': 'Update Now',
+  'common.source.sync.custom': 'Update Now',
+  'common.source.sync.hint.dirty':
+    'Save first — Save writes the new URL and fetches it. Update Now only re-pulls the URL already saved.',
+  'common.source.load.failed':
+    'Could not read the stored configuration, so there is nothing here to save. Close and reopen to try again.'
 };

--- a/src/locales/en-US/models.ts
+++ b/src/locales/en-US/models.ts
@@ -362,5 +362,9 @@ export default {
   'models.form.lora.select': 'Select LoRA',
   'models.form.lora.name': 'LoRA name',
   'models.form.lora.rule.empty': 'Input cannot be empty',
-  'models.form.lora.rule.duplicate': 'LoRA name cannot be duplicated'
+  'models.form.lora.rule.duplicate': 'LoRA name cannot be duplicated',
+  // Model catalog source configuration
+  'models.catalog.source.title': 'Catalog Source',
+  'models.catalog.source.official':
+    'Follows the catalog GPUStack publishes, on top of the one packaged with this release.'
 };

--- a/src/locales/ja-JP/backends.ts
+++ b/src/locales/ja-JP/backends.ts
@@ -58,10 +58,10 @@ export default {
     'To use a different version of a built-in backend (e.g., vLLM, SGLang, MindIE), please add a new version to the existing backend instead of adding a custom backend.',
   // Backend source configuration (built-in backend versions + community library)
   'backend.source.title': 'バックエンドのソース',
-  'backend.source.builtin.title': 'Built-in backend source',
+  'backend.source.builtin.title': 'Built-in Backend',
   'backend.source.builtin.official':
     'Follows the image versions GPUStack publishes for the built-in backends (vLLM, SGLang, MindIE, VoxBox).',
-  'backend.source.community.title': 'Community backend source',
+  'backend.source.community.title': 'Community Backend',
   'backend.source.community.official':
     'Follows the community backend list GPUStack publishes, on top of the one packaged with this release.'
 };

--- a/src/locales/ja-JP/backends.ts
+++ b/src/locales/ja-JP/backends.ts
@@ -55,5 +55,13 @@ export default {
   'backend.add.community': 'Community',
   'backend.community.title': 'Community Backend Marketplace',
   'backend.form.add.hint':
-    'To use a different version of a built-in backend (e.g., vLLM, SGLang, MindIE), please add a new version to the existing backend instead of adding a custom backend.'
+    'To use a different version of a built-in backend (e.g., vLLM, SGLang, MindIE), please add a new version to the existing backend instead of adding a custom backend.',
+  // Backend source configuration (built-in backend versions + community library)
+  'backend.source.title': 'バックエンドのソース',
+  'backend.source.builtin.title': 'Built-in backend source',
+  'backend.source.builtin.official':
+    'Follows the image versions GPUStack publishes for the built-in backends (vLLM, SGLang, MindIE, VoxBox).',
+  'backend.source.community.title': 'Community backend source',
+  'backend.source.community.official':
+    'Follows the community backend list GPUStack publishes, on top of the one packaged with this release.'
 };

--- a/src/locales/ja-JP/common.ts
+++ b/src/locales/ja-JP/common.ts
@@ -312,7 +312,51 @@ export default {
   'common.max': '最大 {count}',
   'common.max.count': '{label} 数',
   'common.validate.group': 'Please complete the {group} configuration',
-  'common.preferences': 'Preferences'
+  'common.preferences': 'Preferences',
+  // Shared by the single-slot source config drawer (src/pages/_components/source-config)
+  'common.source.manage': 'ソースの管理',
+  'common.source.type.builtin': 'Embedded',
+  'common.source.type.builtin.desc':
+    'Serves only what this release was packaged with, with no network access.',
+  'common.source.type.url': 'URL',
+  'common.source.type.url.desc': 'Fetched by the server, can auto-update.',
+  'common.source.type.file': 'Yaml ファイル',
+  'common.source.type.file.desc':
+    'Paste the content directly; never auto-updates.',
+  'common.source.url': 'ソース URL',
+  'common.source.url.scheme':
+    'URL は http:// または https:// で始まる必要があります',
+  'common.source.url.credentials': 'URL に認証情報を含めることはできません',
+  'common.source.url.host': 'URL にホスト名を含める必要があります',
+  'common.source.content': '内容',
+  'common.source.content.hint':
+    'ここに YAML を貼り付けるか、ファイルをインポートしてエディターに読み込んでください。送信されるのはこのテキストのみで、サーバーはファイルを保持しません。',
+  'common.source.save': '保存して同期',
+  'common.source.sync.unchanged': 'リモートの内容に変更はありません。',
+  'common.source.lastSync': '内容の取得時刻: {time}',
+  'common.source.tag.custom': 'カスタム',
+  'common.source.tag.official': 'Official',
+  'common.source.empty.hint':
+    'Your own URL replaces the official source entirely.',
+  'common.source.empty.hint.file':
+    'Leave the content empty to follow the official source — {description}',
+  'common.source.reset': 'Reset to Official Source',
+  'common.source.reset.tip':
+    'Follow the official source again, applied when you save — {description}',
+  'common.source.autoUpdate': 'Auto-update',
+  'common.source.autoUpdate.interval': 'Update Interval (hours)',
+  'common.source.autoUpdate.official.tip':
+    'How often to check the official OTA server for new content. Off leaves the stored content in place until you sync it yourself.',
+  'common.source.autoUpdate.custom.tip':
+    'How often to re-fetch your URL. Off leaves your source untouched until you save or reload it.',
+  'common.source.lastUpdated': 'Last updated {time}',
+  'common.source.official.link': 'Official File',
+  'common.source.sync.official': 'Update Now',
+  'common.source.sync.custom': 'Update Now',
+  'common.source.sync.hint.dirty':
+    'Save first — Save writes the new URL and fetches it. Update Now only re-pulls the URL already saved.',
+  'common.source.load.failed':
+    'Could not read the stored configuration, so there is nothing here to save. Close and reopen to try again.'
 };
 
 // ========== To-Do: Translate Keys (Remove After Translation) ==========

--- a/src/locales/ja-JP/models.ts
+++ b/src/locales/ja-JP/models.ts
@@ -363,7 +363,11 @@ export default {
   'models.form.lora.select': 'Select LoRA',
   'models.form.lora.name': 'LoRA name',
   'models.form.lora.rule.empty': 'Input cannot be empty',
-  'models.form.lora.rule.duplicate': 'LoRA name cannot be duplicated'
+  'models.form.lora.rule.duplicate': 'LoRA name cannot be duplicated',
+  // Model catalog source configuration
+  'models.catalog.source.title': 'カタログのソース',
+  'models.catalog.source.official':
+    'Follows the catalog GPUStack publishes, on top of the one packaged with this release.'
 };
 
 // ========== To-Do: Translate Keys (Remove After Translation) ==========

--- a/src/locales/ru-RU/backends.ts
+++ b/src/locales/ru-RU/backends.ts
@@ -58,10 +58,10 @@ export default {
     'To use a different version of a built-in backend (e.g., vLLM, SGLang, MindIE), please add a new version to the existing backend instead of adding a custom backend.',
   // Backend source configuration (built-in backend versions + community library)
   'backend.source.title': 'Источник бэкендов',
-  'backend.source.builtin.title': 'Built-in backend source',
+  'backend.source.builtin.title': 'Built-in Backend',
   'backend.source.builtin.official':
     'Follows the image versions GPUStack publishes for the built-in backends (vLLM, SGLang, MindIE, VoxBox).',
-  'backend.source.community.title': 'Community backend source',
+  'backend.source.community.title': 'Community Backend',
   'backend.source.community.official':
     'Follows the community backend list GPUStack publishes, on top of the one packaged with this release.'
 };

--- a/src/locales/ru-RU/backends.ts
+++ b/src/locales/ru-RU/backends.ts
@@ -55,7 +55,15 @@ export default {
   'backend.add.community': 'Community',
   'backend.community.title': 'Community Backend Marketplace',
   'backend.form.add.hint':
-    'To use a different version of a built-in backend (e.g., vLLM, SGLang, MindIE), please add a new version to the existing backend instead of adding a custom backend.'
+    'To use a different version of a built-in backend (e.g., vLLM, SGLang, MindIE), please add a new version to the existing backend instead of adding a custom backend.',
+  // Backend source configuration (built-in backend versions + community library)
+  'backend.source.title': 'Источник бэкендов',
+  'backend.source.builtin.title': 'Built-in backend source',
+  'backend.source.builtin.official':
+    'Follows the image versions GPUStack publishes for the built-in backends (vLLM, SGLang, MindIE, VoxBox).',
+  'backend.source.community.title': 'Community backend source',
+  'backend.source.community.official':
+    'Follows the community backend list GPUStack publishes, on top of the one packaged with this release.'
 };
 
 // ========== To-Do: Translate Keys (Remove After Translation) ==========

--- a/src/locales/ru-RU/common.ts
+++ b/src/locales/ru-RU/common.ts
@@ -311,7 +311,51 @@ export default {
   'common.max': 'Макс. {count}',
   'common.max.count': 'Количество {label}',
   'common.validate.group': 'Please complete the {group} configuration',
-  'common.preferences': 'Preferences'
+  'common.preferences': 'Preferences',
+  // Shared by the single-slot source config drawer (src/pages/_components/source-config)
+  'common.source.manage': 'Управление источниками',
+  'common.source.type.builtin': 'Embedded',
+  'common.source.type.builtin.desc':
+    'Serves only what this release was packaged with, with no network access.',
+  'common.source.type.url': 'URL',
+  'common.source.type.url.desc': 'Fetched by the server, can auto-update.',
+  'common.source.type.file': 'Файл Yaml',
+  'common.source.type.file.desc':
+    'Paste the content directly; never auto-updates.',
+  'common.source.url': 'URL источника',
+  'common.source.url.scheme': 'URL должен начинаться с http:// или https://',
+  'common.source.url.credentials': 'URL не должен содержать учётные данные',
+  'common.source.url.host': 'URL должен содержать имя хоста',
+  'common.source.content': 'Содержимое',
+  'common.source.content.hint':
+    'Вставьте YAML здесь или импортируйте файл, чтобы загрузить его в редактор. Отправляется только этот текст — сервер не хранит файл.',
+  'common.source.save': 'Сохранить и синхронизировать',
+  'common.source.sync.unchanged':
+    'Содержимое на удалённой стороне не изменилось.',
+  'common.source.lastSync': 'Содержимое получено: {time}',
+  'common.source.tag.custom': 'Пользовательский',
+  'common.source.tag.official': 'Official',
+  'common.source.empty.hint':
+    'Your own URL replaces the official source entirely.',
+  'common.source.empty.hint.file':
+    'Leave the content empty to follow the official source — {description}',
+  'common.source.reset': 'Reset to Official Source',
+  'common.source.reset.tip':
+    'Follow the official source again, applied when you save — {description}',
+  'common.source.autoUpdate': 'Auto-update',
+  'common.source.autoUpdate.interval': 'Update Interval (hours)',
+  'common.source.autoUpdate.official.tip':
+    'How often to check the official OTA server for new content. Off leaves the stored content in place until you sync it yourself.',
+  'common.source.autoUpdate.custom.tip':
+    'How often to re-fetch your URL. Off leaves your source untouched until you save or reload it.',
+  'common.source.lastUpdated': 'Last updated {time}',
+  'common.source.official.link': 'Official File',
+  'common.source.sync.official': 'Update Now',
+  'common.source.sync.custom': 'Update Now',
+  'common.source.sync.hint.dirty':
+    'Save first — Save writes the new URL and fetches it. Update Now only re-pulls the URL already saved.',
+  'common.source.load.failed':
+    'Could not read the stored configuration, so there is nothing here to save. Close and reopen to try again.'
 };
 
 // ========== To-Do: Translate Keys (Remove After Translation) ==========

--- a/src/locales/ru-RU/models.ts
+++ b/src/locales/ru-RU/models.ts
@@ -366,7 +366,11 @@ export default {
   'models.form.lora.select': 'Select LoRA',
   'models.form.lora.name': 'LoRA name',
   'models.form.lora.rule.empty': 'Input cannot be empty',
-  'models.form.lora.rule.duplicate': 'LoRA name cannot be duplicated'
+  'models.form.lora.rule.duplicate': 'LoRA name cannot be duplicated',
+  // Model catalog source configuration
+  'models.catalog.source.title': 'Источник каталога',
+  'models.catalog.source.official':
+    'Follows the catalog GPUStack publishes, on top of the one packaged with this release.'
 };
 
 // ========== To-Do: Translate Keys (Remove After Translation) ==========

--- a/src/locales/tr-TR/backends.ts
+++ b/src/locales/tr-TR/backends.ts
@@ -54,5 +54,13 @@ export default {
   'backend.add.community': 'Topluluk',
   'backend.community.title': 'Topluluk Altyapı Pazaryeri',
   'backend.form.add.hint':
-    'Yerleşik bir altyapının (örn., vLLM, SGLang, MindIE) farklı sürümünü kullanmak için özel altyapı eklemek yerine mevcut altyapıya yeni sürüm ekleyin.'
+    'Yerleşik bir altyapının (örn., vLLM, SGLang, MindIE) farklı sürümünü kullanmak için özel altyapı eklemek yerine mevcut altyapıya yeni sürüm ekleyin.',
+  // Backend source configuration (built-in backend versions + community library)
+  'backend.source.title': 'Altyapı Kaynağı',
+  'backend.source.builtin.title': 'Built-in backend source',
+  'backend.source.builtin.official':
+    'Follows the image versions GPUStack publishes for the built-in backends (vLLM, SGLang, MindIE, VoxBox).',
+  'backend.source.community.title': 'Community backend source',
+  'backend.source.community.official':
+    'Follows the community backend list GPUStack publishes, on top of the one packaged with this release.'
 };

--- a/src/locales/tr-TR/backends.ts
+++ b/src/locales/tr-TR/backends.ts
@@ -57,10 +57,10 @@ export default {
     'Yerleşik bir altyapının (örn., vLLM, SGLang, MindIE) farklı sürümünü kullanmak için özel altyapı eklemek yerine mevcut altyapıya yeni sürüm ekleyin.',
   // Backend source configuration (built-in backend versions + community library)
   'backend.source.title': 'Altyapı Kaynağı',
-  'backend.source.builtin.title': 'Built-in backend source',
+  'backend.source.builtin.title': 'Built-in Backend',
   'backend.source.builtin.official':
     'Follows the image versions GPUStack publishes for the built-in backends (vLLM, SGLang, MindIE, VoxBox).',
-  'backend.source.community.title': 'Community backend source',
+  'backend.source.community.title': 'Community Backend',
   'backend.source.community.official':
     'Follows the community backend list GPUStack publishes, on top of the one packaged with this release.'
 };

--- a/src/locales/tr-TR/common.ts
+++ b/src/locales/tr-TR/common.ts
@@ -315,5 +315,48 @@ export default {
   'common.max': 'Maks. {count}',
   'common.max.count': '{label} Sayısı',
   'common.validate.group': 'Please complete the {group} configuration',
-  'common.preferences': 'Tercihler'
+  'common.preferences': 'Tercihler',
+  // Shared by the single-slot source config drawer (src/pages/_components/source-config)
+  'common.source.manage': 'Kaynakları Yönet',
+  'common.source.type.builtin': 'Embedded',
+  'common.source.type.builtin.desc':
+    'Serves only what this release was packaged with, with no network access.',
+  'common.source.type.url': 'URL',
+  'common.source.type.url.desc': 'Fetched by the server, can auto-update.',
+  'common.source.type.file': 'Yaml Dosyası',
+  'common.source.type.file.desc':
+    'Paste the content directly; never auto-updates.',
+  'common.source.url': 'Kaynak URL',
+  'common.source.url.scheme': 'URL http:// veya https:// ile başlamalıdır',
+  'common.source.url.credentials': 'URL kimlik bilgileri içermemelidir',
+  'common.source.url.host': 'URL bir ana bilgisayar adı içermelidir',
+  'common.source.content': 'İçerik',
+  'common.source.content.hint':
+    'YAML içeriğini buraya yapıştırın veya bir dosya içe aktararak düzenleyiciye yükleyin. Yalnızca bu metin gönderilir — sunucu hiçbir dosya saklamaz.',
+  'common.source.save': 'Kaydet ve Eşitle',
+  'common.source.sync.unchanged': 'Uzak içerik değişmedi.',
+  'common.source.lastSync': 'İçerik {time} tarihinde alındı',
+  'common.source.tag.custom': 'Özel',
+  'common.source.tag.official': 'Official',
+  'common.source.empty.hint':
+    'Your own URL replaces the official source entirely.',
+  'common.source.empty.hint.file':
+    'Leave the content empty to follow the official source — {description}',
+  'common.source.reset': 'Reset to Official Source',
+  'common.source.reset.tip':
+    'Follow the official source again, applied when you save — {description}',
+  'common.source.autoUpdate': 'Auto-update',
+  'common.source.autoUpdate.interval': 'Update Interval (hours)',
+  'common.source.autoUpdate.official.tip':
+    'How often to check the official OTA server for new content. Off leaves the stored content in place until you sync it yourself.',
+  'common.source.autoUpdate.custom.tip':
+    'How often to re-fetch your URL. Off leaves your source untouched until you save or reload it.',
+  'common.source.lastUpdated': 'Last updated {time}',
+  'common.source.official.link': 'Official File',
+  'common.source.sync.official': 'Update Now',
+  'common.source.sync.custom': 'Update Now',
+  'common.source.sync.hint.dirty':
+    'Save first — Save writes the new URL and fetches it. Update Now only re-pulls the URL already saved.',
+  'common.source.load.failed':
+    'Could not read the stored configuration, so there is nothing here to save. Close and reopen to try again.'
 };

--- a/src/locales/tr-TR/models.ts
+++ b/src/locales/tr-TR/models.ts
@@ -362,7 +362,11 @@ export default {
   'models.form.lora.select': 'Select LoRA',
   'models.form.lora.name': 'LoRA name',
   'models.form.lora.rule.empty': 'Input cannot be empty',
-  'models.form.lora.rule.duplicate': 'LoRA name cannot be duplicated'
+  'models.form.lora.rule.duplicate': 'LoRA name cannot be duplicated',
+  // Model catalog source configuration
+  'models.catalog.source.title': 'Katalog Kaynağı',
+  'models.catalog.source.official':
+    'Follows the catalog GPUStack publishes, on top of the one packaged with this release.'
 };
 
 // ========== To-Do: Translate Keys (Remove After Translation) ==========

--- a/src/locales/zh-CN/backends.ts
+++ b/src/locales/zh-CN/backends.ts
@@ -51,5 +51,13 @@ export default {
   'backend.add.community': '社区',
   'backend.community.title': '社区后端市场',
   'backend.form.add.hint':
-    '如果需要使用内置后端（如 vLLM、SGLang、MindIE）的其他版本，请在对应后端中添加新版本，而不是添加自定义后端。'
+    '如果需要使用内置后端（如 vLLM、SGLang、MindIE）的其他版本，请在对应后端中添加新版本，而不是添加自定义后端。',
+  // Backend source configuration (built-in backend versions + community library)
+  'backend.source.title': '后端来源',
+  'backend.source.builtin.title': '内置后端来源',
+  'backend.source.builtin.official':
+    '跟随 GPUStack 发布的内置后端（vLLM、SGLang、MindIE、VoxBox）镜像版本。',
+  'backend.source.community.title': '社区后端来源',
+  'backend.source.community.official':
+    '在随本版本打包的社区后端清单之上，跟随 GPUStack 发布的官方清单。'
 };

--- a/src/locales/zh-CN/backends.ts
+++ b/src/locales/zh-CN/backends.ts
@@ -54,10 +54,10 @@ export default {
     '如果需要使用内置后端（如 vLLM、SGLang、MindIE）的其他版本，请在对应后端中添加新版本，而不是添加自定义后端。',
   // Backend source configuration (built-in backend versions + community library)
   'backend.source.title': '后端来源',
-  'backend.source.builtin.title': '内置后端来源',
+  'backend.source.builtin.title': '内置后端',
   'backend.source.builtin.official':
     '跟随 GPUStack 发布的内置后端（vLLM、SGLang、MindIE、VoxBox）镜像版本。',
-  'backend.source.community.title': '社区后端来源',
+  'backend.source.community.title': '社区后端',
   'backend.source.community.official':
     '在随本版本打包的社区后端清单之上，跟随 GPUStack 发布的官方清单。'
 };

--- a/src/locales/zh-CN/common.ts
+++ b/src/locales/zh-CN/common.ts
@@ -301,5 +301,43 @@ export default {
   'common.max': '最大 {count}',
   'common.max.count': '{label} 数量',
   'common.validate.group': '请填写完整的{group}配置',
-  'common.preferences': '偏好设置'
+  'common.preferences': '偏好设置',
+  // Shared by the source config drawer (src/pages/_components/source-config)
+  'common.source.manage': '管理来源',
+  'common.source.type.builtin': '内嵌',
+  'common.source.type.builtin.desc': '只用随本版本打包的内容，不访问网络。',
+  'common.source.type.url': 'URL',
+  'common.source.type.url.desc': '由服务端定期拉取，可自动更新。',
+  'common.source.type.file': 'Yaml 文件',
+  'common.source.type.file.desc': '直接粘贴内容，不会自动更新。',
+  'common.source.url': '来源 URL',
+  'common.source.url.scheme': 'URL 必须以 http:// 或 https:// 开头',
+  'common.source.url.credentials': 'URL 中不能包含凭据',
+  'common.source.url.host': 'URL 必须包含主机名',
+  'common.source.content': '内容',
+  'common.source.content.hint':
+    '在此粘贴 YAML，或导入文件将其载入编辑器。只有这段文本会被提交，服务端不保存文件。',
+  'common.source.save': '保存',
+  'common.source.sync.unchanged': '远端内容没有变化。',
+  'common.source.lastSync': '内容取自 {time}',
+  'common.source.tag.custom': '自定义',
+  'common.source.tag.official': '官方',
+  'common.source.empty.hint': '填入你自己的 URL 会完整替换官方来源。',
+  'common.source.empty.hint.file': '内容留空则使用官方来源——{description}',
+  'common.source.reset': '重置为官方来源',
+  'common.source.reset.tip': '改回官方来源（保存后生效）——{description}',
+  'common.source.autoUpdate': '自动更新',
+  'common.source.autoUpdate.interval': '更新间隔（小时）',
+  'common.source.autoUpdate.official.tip':
+    '多久检查一次官方 OTA 服务器是否有新内容。关闭后已存内容保持不变，直到你手动同步。',
+  'common.source.autoUpdate.custom.tip':
+    '多久重新拉取一次你的 URL。关闭后你的来源保持不变，直到你保存或重新拉取。',
+  'common.source.lastUpdated': '上次更新 {time}',
+  'common.source.official.link': '官方文件',
+  'common.source.sync.official': '立即更新',
+  'common.source.sync.custom': '立即更新',
+  'common.source.sync.hint.dirty':
+    '请先保存——保存会写入新 URL 并拉取它。立即更新只会重新拉取已保存的 URL。',
+  'common.source.load.failed':
+    '无法读取已保存的配置，因此这里没有可保存的内容。请关闭后重新打开重试。'
 };

--- a/src/locales/zh-CN/models.ts
+++ b/src/locales/zh-CN/models.ts
@@ -344,5 +344,9 @@ export default {
   'models.form.lora.select': '选择 LoRA',
   'models.form.lora.name': 'LoRA 名称',
   'models.form.lora.rule.empty': '输入不能为空',
-  'models.form.lora.rule.duplicate': 'LoRA name 不能重复'
+  'models.form.lora.rule.duplicate': 'LoRA name 不能重复',
+  // Model catalog source configuration
+  'models.catalog.source.title': '模型库来源',
+  'models.catalog.source.official':
+    '在随本版本打包的内置模型库之上，跟随 GPUStack 发布的官方模型库。'
 };

--- a/src/pages/_components/source-config/apis.ts
+++ b/src/pages/_components/source-config/apis.ts
@@ -1,0 +1,44 @@
+import { request } from '@umijs/max';
+import type {
+  SourceConfig,
+  SourceConfigUpsert,
+  SourceProbeKind,
+  SourceWriteResult
+} from './types';
+
+// One endpoint family for all three kinds, keyed by the same name the probe
+// reports its `kinds` under — so a slot addresses its own configuration from
+// `slot.kind` alone, with no per-consumer wiring and no name translation.
+export const OTA_SOURCE_API = '/ota-sources';
+
+const sourceUrl = (kind: SourceProbeKind) => `${OTA_SOURCE_API}/${kind}`;
+
+export async function queryOtaSource(kind: SourceProbeKind) {
+  return request<SourceConfig>(sourceUrl(kind), {
+    method: 'GET'
+  });
+}
+
+// `skipErrorHandler`: a refused write — a URL that will not fetch, an update
+// that would take away a backend version still in use — is rendered inline in
+// the panel that sent it, not as a global toast.
+export async function updateOtaSource(
+  kind: SourceProbeKind,
+  data: SourceConfigUpsert
+) {
+  return request<SourceWriteResult>(sourceUrl(kind), {
+    method: 'PUT',
+    data,
+    skipErrorHandler: true
+  });
+}
+
+// Refresh this kind now, from whichever layer serves it: the configured URL
+// while there is one, else the official slot. The official half runs on the
+// leader, so a standby answers 503 — surfaced inline like any other failure.
+export async function reloadOtaSource(kind: SourceProbeKind) {
+  return request<SourceWriteResult>(`${sourceUrl(kind)}/reload`, {
+    method: 'POST',
+    skipErrorHandler: true
+  });
+}

--- a/src/pages/_components/source-config/config.ts
+++ b/src/pages/_components/source-config/config.ts
@@ -1,0 +1,19 @@
+// Runtime values for the source configuration UI. Split from `types.ts` so the
+// two consumers that only ask "did this record come from a custom source?"
+// (the catalog card and the backend select) pull in a constant instead of the
+// drawer's module graph.
+
+// Where a source's content comes from. `builtin` / `official` are written by
+// the platform itself (the packaged baseline and the official refresh task) and
+// never appear in a request body — only `file` and `url` are configurable.
+export const SourceTypeValueMap = {
+  BUILTIN: 'builtin',
+  OFFICIAL: 'official',
+  FILE: 'file',
+  URL: 'url'
+} as const;
+
+// Whether a materialized record came from an admin-configured source rather
+// than from the packaged baseline or the official refresh.
+export const isCustomSourceType = (type?: string | null) =>
+  type === SourceTypeValueMap.FILE || type === SourceTypeValueMap.URL;

--- a/src/pages/_components/source-config/drawer.tsx
+++ b/src/pages/_components/source-config/drawer.tsx
@@ -1,19 +1,28 @@
-import { CollapsePanel, FormDrawer, TextAttribute } from '@gpustack/core-ui';
+import {
+  FormDrawer,
+  IconFont,
+  SegmentLine,
+  TextAttribute
+} from '@gpustack/core-ui';
 import { useIntl } from '@umijs/max';
+import { Tabs } from 'antd';
 import { createStyles } from 'antd-style';
 import React, { useEffect, useState } from 'react';
 import SourceSlotForm from './slot-form';
-import type { SourceScopeConfig, SourceSlotConfig } from './types';
+import type {
+  SourceProbeKind,
+  SourceScopeConfig,
+  SourceSlotConfig
+} from './types';
 import { useProbeStatus } from './use-source-config';
 
 const useStyles = createStyles(({ css }) => ({
-  // A ghost collapse draws no divider between items, so an expanded panel's
-  // last row — its Save button — lands directly against the next panel's
-  // title, reading as if the button belonged to that title.
-  panels: css`
-    .ant-collapse-item + .ant-collapse-item {
-      margin-top: 24px;
-    }
+  // The rule under the labels is what makes them read as a tab bar rather than
+  // as two links above a form — the same treatment the backend form/YAML switch
+  // gets (`src/pages/backends/components/add-modal.tsx`).
+  tabBar: css`
+    margin-bottom: 16px;
+    border-bottom: 1px solid var(--ant-color-split);
   `
 }));
 
@@ -30,14 +39,14 @@ interface SourceConfigDrawerProps {
  *
  * The catalog scope owns one kind and shows its form directly; the backend
  * scope owns two — the built-in backend versions and the community library —
- * and stacks them as panels that expand independently, because they are two
- * separate configurations rather than two settings of one.
+ * and puts them behind a tab bar, because they are two separate configurations
+ * rather than two settings of one.
  *
- * Each panel saves itself: a kind's whole configuration is one object on the
- * server, so one panel is one request, and the drawer's footer carries no Save
- * that would have to guess which panel it meant.
+ * Each tab saves itself: a kind's whole configuration is one object on the
+ * server, so one tab is one request, and its Save sits at the end of the form it
+ * belongs to rather than in a drawer footer shared with the other tab.
  *
- * `/source-probe` reports every kind at once — the leader-only state each panel
+ * `/source-probe` reports every kind at once — the leader-only state each tab
  * shows and the OTA server its official file link is built from — so it is
  * fetched once here and handed down.
  */
@@ -51,18 +60,22 @@ const SourceConfigDrawer: React.FC<SourceConfigDrawerProps> = ({
   const { styles } = useStyles();
   const { probeStatus, loadProbe } = useProbeStatus(scope.probe);
   const slots = scope.slots;
-  const [activeKeys, setActiveKeys] = useState<string[]>([slots[0].kind]);
+  const [activeKind, setActiveKind] = useState<SourceProbeKind>(slots[0].kind);
+  // The fixed bottom bar, as an element rather than a ref: the form rendering
+  // into it has to re-render once it exists, and a ref's `.current` does not
+  // say when that is.
+  const [footerEl, setFooterEl] = useState<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!open) {
       return;
     }
-    setActiveKeys([slots[0].kind]);
+    setActiveKind(slots[0].kind);
     loadProbe();
     // the fetch is tied to open; loadProbe is recreated every render
   }, [open]);
 
-  // A panel saved: its merged content moved, so the probe and the list behind
+  // A tab saved: its merged content moved, so the probe and the list behind
   // the drawer are both stale.
   const handleSlotSaved = () => {
     loadProbe();
@@ -75,15 +88,19 @@ const SourceConfigDrawer: React.FC<SourceConfigDrawerProps> = ({
       status={probeStatus?.kinds?.[slot.kind]}
       otaServerUrl={probeStatus?.ota_server_url || ''}
       onSaved={handleSlotSaved}
+      onCancel={onCancel}
+      // Every tab stays mounted, so the bar goes to the one on screen — the
+      // others render no buttons at all.
+      footerContainer={slot.kind === activeKind ? footerEl : null}
     ></SourceSlotForm>
   );
 
   // Only what departs from the default is worth marking — following the official
-  // source is the default, so tagging it too is noise on every collapsed panel.
-  // That leaves the one state the panel cannot show on its own: the card row
+  // source is the default, so tagging it too is noise on every tab. That leaves
+  // the one state a tab cannot show while the other one is open: the card row
   // says which kind of source is configured, but not whether the URL in it is
   // the admin's or the official file's own address.
-  const renderPanelLabel = (slot: SourceSlotConfig) => (
+  const renderTabLabel = (slot: SourceSlotConfig) => (
     <span>
       {slot.titleKey && intl.formatMessage({ id: slot.titleKey })}
       {probeStatus?.kinds?.[slot.kind]?.official_masked && (
@@ -100,11 +117,12 @@ const SourceConfigDrawer: React.FC<SourceConfigDrawerProps> = ({
       open={open}
       onCancel={onCancel}
       width={620}
-      // `false`, not `null`: FormDrawer falls back to its default Cancel/Save
-      // footer on nullish. Every slot form ends in its own Save row, so a
-      // drawer-level footer would either duplicate it or, with two panels, have
-      // to guess which panel it meant.
-      footer={false}
+      // The bar itself, empty: what goes in it belongs to whichever tab is on
+      // screen, and is rendered from there (see `footerContainer`). A
+      // drawer-level ModalFooter would have to reach back for the state its
+      // buttons read — whether the form is dirty, whether a write is in flight —
+      // and a `false` here would leave the buttons scrolling with the content.
+      footer={<div ref={setFooterEl} />}
     >
       {/* FormDrawer destroys its children on close, so every panel re-reads its
           config on open without a gate here — one would only empty the drawer
@@ -112,21 +130,40 @@ const SourceConfigDrawer: React.FC<SourceConfigDrawerProps> = ({
       {slots.length === 1 ? (
         renderSlot(slots[0])
       ) : (
-        <div className={styles.panels}>
-          <CollapsePanel
-            accordion={false}
-            activeKey={activeKeys}
-            onChange={(keys) =>
-              setActiveKeys(Array.isArray(keys) ? keys : [keys])
-            }
+        <>
+          <div className={styles.tabBar}>
+            <SegmentLine
+              theme="light"
+              size="middle"
+              style={{ width: '100%' }}
+              value={activeKind}
+              onChange={(value) => setActiveKind(value as SourceProbeKind)}
+              options={slots.map((slot) => ({
+                label: renderTabLabel(slot),
+                value: slot.kind,
+                icon: slot.iconType ? (
+                  <IconFont type={slot.iconType}></IconFont>
+                ) : undefined
+              }))}
+            ></SegmentLine>
+          </div>
+          {/* The labels live on the control above, so the stock bar is rendered
+              away. Tabs is here for what it does to the panes rather than for
+              its bar: an inactive tab keeps its form mounted, so an unsaved URL
+              survives a look at the other kind — the same reason the collapse
+              this replaced forced its panels to render. */}
+          <Tabs
+            renderTabBar={() => <></>}
+            activeKey={activeKind}
             items={slots.map((slot) => ({
               key: slot.kind,
-              label: renderPanelLabel(slot),
-              forceRender: true,
+              // Required by the item type, and never rendered: the bar it would
+              // appear in is the one replaced above.
+              label: '',
               children: renderSlot(slot)
             }))}
-          ></CollapsePanel>
-        </div>
+          ></Tabs>
+        </>
       )}
     </FormDrawer>
   );

--- a/src/pages/_components/source-config/drawer.tsx
+++ b/src/pages/_components/source-config/drawer.tsx
@@ -1,0 +1,135 @@
+import { CollapsePanel, FormDrawer, TextAttribute } from '@gpustack/core-ui';
+import { useIntl } from '@umijs/max';
+import { createStyles } from 'antd-style';
+import React, { useEffect, useState } from 'react';
+import SourceSlotForm from './slot-form';
+import type { SourceScopeConfig, SourceSlotConfig } from './types';
+import { useProbeStatus } from './use-source-config';
+
+const useStyles = createStyles(({ css }) => ({
+  // A ghost collapse draws no divider between items, so an expanded panel's
+  // last row — its Save button — lands directly against the next panel's
+  // title, reading as if the button belonged to that title.
+  panels: css`
+    .ant-collapse-item + .ant-collapse-item {
+      margin-top: 24px;
+    }
+  `
+}));
+
+interface SourceConfigDrawerProps {
+  open: boolean;
+  onCancel: () => void;
+  // The merged result changed, so the list behind the drawer is stale.
+  onSaved?: () => void;
+  config: SourceScopeConfig;
+}
+
+/**
+ * Configures the source of every kind of content a scope owns.
+ *
+ * The catalog scope owns one kind and shows its form directly; the backend
+ * scope owns two — the built-in backend versions and the community library —
+ * and stacks them as panels that expand independently, because they are two
+ * separate configurations rather than two settings of one.
+ *
+ * Each panel saves itself: a kind's whole configuration is one object on the
+ * server, so one panel is one request, and the drawer's footer carries no Save
+ * that would have to guess which panel it meant.
+ *
+ * `/source-probe` reports every kind at once — the leader-only state each panel
+ * shows and the OTA server its official file link is built from — so it is
+ * fetched once here and handed down.
+ */
+const SourceConfigDrawer: React.FC<SourceConfigDrawerProps> = ({
+  open,
+  onCancel,
+  onSaved,
+  config: scope
+}) => {
+  const intl = useIntl();
+  const { styles } = useStyles();
+  const { probeStatus, loadProbe } = useProbeStatus(scope.probe);
+  const slots = scope.slots;
+  const [activeKeys, setActiveKeys] = useState<string[]>([slots[0].kind]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    setActiveKeys([slots[0].kind]);
+    loadProbe();
+    // the fetch is tied to open; loadProbe is recreated every render
+  }, [open]);
+
+  // A panel saved: its merged content moved, so the probe and the list behind
+  // the drawer are both stale.
+  const handleSlotSaved = () => {
+    loadProbe();
+    onSaved?.();
+  };
+
+  const renderSlot = (slot: SourceSlotConfig) => (
+    <SourceSlotForm
+      slot={slot}
+      status={probeStatus?.kinds?.[slot.kind]}
+      otaServerUrl={probeStatus?.ota_server_url || ''}
+      onSaved={handleSlotSaved}
+    ></SourceSlotForm>
+  );
+
+  // Only what departs from the default is worth marking — following the official
+  // source is the default, so tagging it too is noise on every collapsed panel.
+  // That leaves the one state the panel cannot show on its own: the card row
+  // says which kind of source is configured, but not whether the URL in it is
+  // the admin's or the official file's own address.
+  const renderPanelLabel = (slot: SourceSlotConfig) => (
+    <span>
+      {slot.titleKey && intl.formatMessage({ id: slot.titleKey })}
+      {probeStatus?.kinds?.[slot.kind]?.official_masked && (
+        <TextAttribute>
+          {intl.formatMessage({ id: 'common.source.tag.custom' })}
+        </TextAttribute>
+      )}
+    </span>
+  );
+
+  return (
+    <FormDrawer
+      title={intl.formatMessage({ id: scope.titleKey })}
+      open={open}
+      onCancel={onCancel}
+      width={620}
+      // `false`, not `null`: FormDrawer falls back to its default Cancel/Save
+      // footer on nullish. Every slot form ends in its own Save row, so a
+      // drawer-level footer would either duplicate it or, with two panels, have
+      // to guess which panel it meant.
+      footer={false}
+    >
+      {/* FormDrawer destroys its children on close, so every panel re-reads its
+          config on open without a gate here — one would only empty the drawer
+          for the duration of the closing animation. */}
+      {slots.length === 1 ? (
+        renderSlot(slots[0])
+      ) : (
+        <div className={styles.panels}>
+          <CollapsePanel
+            accordion={false}
+            activeKey={activeKeys}
+            onChange={(keys) =>
+              setActiveKeys(Array.isArray(keys) ? keys : [keys])
+            }
+            items={slots.map((slot) => ({
+              key: slot.kind,
+              label: renderPanelLabel(slot),
+              forceRender: true,
+              children: renderSlot(slot)
+            }))}
+          ></CollapsePanel>
+        </div>
+      )}
+    </FormDrawer>
+  );
+};
+
+export default SourceConfigDrawer;

--- a/src/pages/_components/source-config/index.tsx
+++ b/src/pages/_components/source-config/index.tsx
@@ -1,0 +1,61 @@
+import { IconFont, useBodyScroll } from '@gpustack/core-ui';
+import { useAccess, useIntl } from '@umijs/max';
+import { Button } from 'antd';
+import React, { useState } from 'react';
+import SourceConfigDrawer from './drawer';
+import type { SourceScopeConfig } from './types';
+
+interface SourceConfigEntryProps {
+  config: SourceScopeConfig;
+  // The merged result changed, so the list behind the drawer is stale.
+  onSaved?: () => void;
+}
+
+/**
+ * Whether the entry belongs in this user's toolbar at all. Both source
+ * endpoints are platform-admin only on the server, so it is hidden for everyone
+ * else rather than left to fail with a 403 — and the pages carrying it are
+ * `canSeeOrgAdmin`, which extensions widen past platform admin.
+ *
+ * The caller does the hiding, which is why this is a hook rather than an
+ * `Access` wrapper inside the entry: both toolbars are an antd `Space`, and a
+ * `Space` reads its children as items *before* they render. An element that
+ * renders nothing still occupies an item, so the gap around it survives — only
+ * an absent element leaves no trace.
+ */
+export const useSourceConfigVisible = () => !!useAccess().canSeeAdmin;
+
+const SourceConfigEntry: React.FC<SourceConfigEntryProps> = ({
+  config,
+  onSaved
+}) => {
+  const intl = useIntl();
+  const { saveScrollHeight, restoreScrollHeight } = useBodyScroll();
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => {
+    saveScrollHeight();
+    setOpen(true);
+  };
+
+  const handleCancel = () => {
+    setOpen(false);
+    restoreScrollHeight();
+  };
+
+  return (
+    <>
+      <Button icon={<IconFont type="icon-settings" />} onClick={handleOpen}>
+        {intl.formatMessage({ id: 'common.source.manage' })}
+      </Button>
+      <SourceConfigDrawer
+        open={open}
+        onCancel={handleCancel}
+        onSaved={onSaved}
+        config={config}
+      ></SourceConfigDrawer>
+    </>
+  );
+};
+
+export default SourceConfigEntry;

--- a/src/pages/_components/source-config/index.tsx
+++ b/src/pages/_components/source-config/index.tsx
@@ -1,6 +1,7 @@
-import { IconFont, useBodyScroll } from '@gpustack/core-ui';
+import { SettingOutlined } from '@ant-design/icons';
+import { useBodyScroll } from '@gpustack/core-ui';
 import { useAccess, useIntl } from '@umijs/max';
-import { Button } from 'antd';
+import { Button, Tooltip } from 'antd';
 import React, { useState } from 'react';
 import SourceConfigDrawer from './drawer';
 import type { SourceScopeConfig } from './types';
@@ -45,9 +46,12 @@ const SourceConfigEntry: React.FC<SourceConfigEntryProps> = ({
 
   return (
     <>
-      <Button icon={<IconFont type="icon-settings" />} onClick={handleOpen}>
-        {intl.formatMessage({ id: 'common.source.manage' })}
-      </Button>
+      {/* Icon only, with the label as its tooltip: a secondary action sitting
+          beside the toolbar's primary button. Default styling, so it keeps the
+          border that tells it apart from the page behind it. */}
+      <Tooltip title={intl.formatMessage({ id: 'common.source.manage' })}>
+        <Button icon={<SettingOutlined />} onClick={handleOpen}></Button>
+      </Tooltip>
       <SourceConfigDrawer
         open={open}
         onCancel={handleCancel}

--- a/src/pages/_components/source-config/probe.ts
+++ b/src/pages/_components/source-config/probe.ts
@@ -1,0 +1,16 @@
+import { request } from '@umijs/max';
+import type { SourceProbeStatus } from './types';
+
+export const SOURCE_PROBE_API = '/source-probe';
+
+// One call reports every kind's live state, so the drawer shares it across
+// scopes. Read-only; the global error handler is fine for its failures.
+//
+// The status read is all the UI needs here: `POST /source-probe` forces a round
+// over *all three* kinds, which is an operator's verb. A panel's refresh button
+// reloads the one kind it is showing — see `reloadOtaSource`.
+export async function querySourceProbe() {
+  return request<SourceProbeStatus>(SOURCE_PROBE_API, {
+    method: 'GET'
+  });
+}

--- a/src/pages/_components/source-config/slot-form.tsx
+++ b/src/pages/_components/source-config/slot-form.tsx
@@ -1,0 +1,758 @@
+import useUserSettings from '@/hooks/use-user-settings';
+import {
+  QuestionCircleOutlined,
+  SyncOutlined,
+  UndoOutlined
+} from '@ant-design/icons';
+import {
+  AlertBlockInfo,
+  CardRadioGroup,
+  CheckboxField,
+  Input as CInput,
+  InputNumber as CInputNumber,
+  TextAttribute,
+  useSubmitLock
+} from '@gpustack/core-ui';
+import { YamlEditor } from '@gpustack/core-ui/yaml-editor';
+import { useIntl } from '@umijs/max';
+import { Button, Flex, Form, message, Tooltip } from 'antd';
+import { createStyles } from 'antd-style';
+import dayjs from 'dayjs';
+import React, { useEffect, useRef, useState } from 'react';
+import { SourceTypeValueMap } from './config';
+import type {
+  CustomSourceUpsert,
+  SourceConfig,
+  SourceConfigUpsert,
+  SourceKindStatus,
+  SourceSlotConfig,
+  SourceType
+} from './types';
+import { OFFICIAL_DEFAULT_HOURS, useSlotConfig } from './use-source-config';
+
+const MAX_AUTO_UPDATE_HOURS = 168;
+
+// The card row's value. Two of the cards say which source serves, the third
+// says none of them does — so this is not a `SourceType`, and never reaches the
+// request body.
+type SlotMode = SourceType | typeof SourceTypeValueMap.BUILTIN;
+
+const useStyles = createStyles(({ css }) => ({
+  metaLine: css`
+    font-size: var(--font-size-12);
+    line-height: 20px;
+    color: var(--ant-color-text-tertiary);
+  `,
+  hintIcon: css`
+    color: var(--ant-color-text-tertiary);
+  `,
+  // ``.label-text`` is a flex row sized by its tallest child, and the label sits
+  // right above the value: the badge's stock 18px line and vertical padding
+  // would grow that row into the text below it. Doubled selector to outrank the
+  // library's own class, which loads first.
+  officialTag: css`
+    && {
+      line-height: 14px;
+      padding-block: 0;
+      padding-inline: 6px;
+    }
+  `,
+  // Flush left, so the row reads as part of the field above it rather than as
+  // an indented toolbar.
+  linkRow: css`
+    .ant-btn {
+      padding-inline: 0;
+    }
+  `
+}));
+
+// A failed write answers with `{code, reason, message}`; these requests opt out
+// of the global error toast so the reason lands inside the drawer instead.
+const errorMessageOf = (error: any): string =>
+  error?.response?.data?.message ||
+  error?.data?.message ||
+  error?.message ||
+  '';
+
+// The editor is seeded with a commented schema hint, and empty content is a
+// *valid* source the server would normalize into an empty feed — so the
+// untouched hint counts as "nothing configured", the same as a blank box.
+const hasMeaningfulContent = (text: string) =>
+  text.split('\n').some((line) => line.trim() && !line.trim().startsWith('#'));
+
+/**
+ * The refresh cadence, in hours, of whichever layer is showing. One number
+ * carries both facts the server stores in one field: 0 is off, and any other
+ * value is how often it re-reads — so the checkbox derives from the number
+ * rather than being a second source of truth that could disagree with it.
+ */
+const AutoUpdateField: React.FC<{
+  description: string;
+  hours: number;
+  onChange: (hours: number) => void;
+}> = ({ description, hours, onChange }) => {
+  const intl = useIntl();
+  return (
+    <>
+      <CheckboxField
+        label={intl.formatMessage({ id: 'common.source.autoUpdate' })}
+        description={description}
+        checked={hours > 0}
+        onChange={(e) =>
+          onChange(e.target.checked ? OFFICIAL_DEFAULT_HOURS : 0)
+        }
+      ></CheckboxField>
+      {/* Off is the absence of the box rather than a value in it, so the
+          interval starts at 1 — clearing the box normalizes back to it. */}
+      {hours > 0 && (
+        <CInputNumber
+          label={intl.formatMessage({
+            id: 'common.source.autoUpdate.interval'
+          })}
+          min={1}
+          max={MAX_AUTO_UPDATE_HOURS}
+          precision={0}
+          value={hours}
+          onChange={(value) =>
+            onChange(Math.min(Number(value) || 1, MAX_AUTO_UPDATE_HOURS))
+          }
+        ></CInputNumber>
+      )}
+    </>
+  );
+};
+
+interface SourceSlotFormProps {
+  slot: SourceSlotConfig;
+  // This kind's entry in the shared probe status: the last failed refresh and
+  // the file it is published as.
+  status?: SourceKindStatus;
+  // The directory the official files are published under.
+  otaServerUrl: string;
+  // A write landed, so the probe and the list behind the drawer are stale.
+  onSaved: () => void;
+}
+
+/**
+ * Configures one kind of content: where it comes from, and how often that is
+ * re-read.
+ *
+ * One row of cards answers the whole question of where it comes from — a URL,
+ * (for the catalog) inline text, or what this release was packaged with — and
+ * everything below the row describes whichever card is selected. The factory
+ * card sits last because it is the fall-back: it takes remote content out of
+ * service and leaves the packaged baseline serving on its own, keeping what is
+ * configured parked for the way back. It is a value like any other, applied by
+ * Save rather than the moment it is clicked, which is what lets a source that
+ * turns out to be broken be corrected without first putting it back in service.
+ *
+ * Between the two online cards, a source of your own *is* the input being
+ * filled in; the official file's own address is what the box holds by
+ * default, and Reset is how you get back to it. The auto update cadence belongs
+ * to whichever of the two is in effect, so one checkbox edits one number.
+ *
+ * A URL is fetched server-side on every save, which makes Save the re-sync
+ * action too; the refetch button is the cheaper variant that reuses what is
+ * already stored, and is disabled while the form is dirty.
+ */
+const SourceSlotForm: React.FC<SourceSlotFormProps> = ({
+  slot,
+  status,
+  otaServerUrl,
+  onSaved
+}) => {
+  const intl = useIntl();
+  const { styles, cx } = useStyles();
+  const { isDarkTheme } = useUserSettings();
+  const [form] = Form.useForm();
+  const { loading: submitting, guard, run } = useSubmitLock();
+  const { config, load, save, reload } = useSlotConfig(slot.kind);
+
+  // Whether remote content serves at all. The factory card is this axis, so it
+  // is an unsaved edit like everything else in the form until Save writes it.
+  const [remoteEnabled, setRemoteEnabled] = useState(true);
+  // The editor is uncontrolled (a controlled monaco reformats on every
+  // keystroke), so its text is read through the ref and only mirrored into
+  // state when the branch is about to unmount.
+  const editorRef = useRef<any>(null);
+  // Whether that text amounts to content, which is what decides custom vs
+  // official and so has to re-render — the one thing about the editor's content
+  // that is tracked live. The text itself stays out of state for the reason
+  // above.
+  const [fileHasContent, setFileHasContent] = useState(false);
+  const [formState, setFormState] = useState({
+    sourceType: SourceTypeValueMap.URL as SourceType,
+    content: '',
+    customHours: 0,
+    officialHours: OFFICIAL_DEFAULT_HOURS
+  });
+  const urlValue: string = Form.useWatch('url', form) ?? '';
+  const [alert, setAlert] = useState('');
+  const [reloading, setReloading] = useState(false);
+  // The first read failed, so nothing on screen came from the server. Its own
+  // state rather than an `alert` string: editing a field clears `alert`, and
+  // this has to outlive that — the form stays unwritable until a read succeeds.
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  const isFileMode =
+    slot.allowFile && formState.sourceType === SourceTypeValueMap.FILE;
+  const isUrlMode = !isFileMode;
+  // The row projects the two states rather than holding a third of its own:
+  // which source is configured survives being taken out of service, which is
+  // exactly what parking it means.
+  const mode: SlotMode = remoteEnabled
+    ? formState.sourceType
+    : SourceTypeValueMap.BUILTIN;
+
+  // The official file this kind publishes — the starting point for content of
+  // your own, which replaces exactly that file. Guarded to http(s)
+  // because the OTA server is server-configurable and this ends up in an href.
+  // The trailing slash is stripped the way the server strips it joining the same
+  // two halves (`sources/probe.py:_ota_url`, which tolerates one because a
+  // configured OTA server URL commonly carries it): the address has to come out
+  // byte-identical to the one the server reads as "follow the official source",
+  // or an OTA server URL configured with a trailing slash would fail
+  // `urlIsOfficial` below and save the official address as a custom URL.
+  const officialFileUrl =
+    status?.filename && /^https?:\/\//i.test(otaServerUrl)
+      ? `${otaServerUrl.replace(/\/+$/, '')}/${status.filename}`
+      : '';
+  // The box holds the official file's own address, which the server reads
+  // as "follow the official source" (``_means_the_official_source``) — so the
+  // two agree on what is typed there. Also what the badge marks: the one
+  // address a user did not choose is worth telling apart from one they did.
+  const urlIsOfficial =
+    !!officialFileUrl && urlValue.trim() === officialFileUrl;
+  // What is filled in decides the source: a source of the admin's own, or the
+  // official one.
+  const customConfigured = isFileMode
+    ? fileHasContent
+    : !!urlValue.trim() && !urlIsOfficial;
+  // Only the editor gets this: downloading the official file is what inline
+  // content of your own starts from, while the URL branch has nothing to open —
+  // its box already shows the address it would otherwise follow. Absent until
+  // the probe reports an OTA server URL.
+  const officialFileLink = officialFileUrl ? (
+    <a
+      className="m-l-8"
+      href={officialFileUrl}
+      target="_blank"
+      rel="noreferrer"
+    >
+      {intl.formatMessage({ id: 'common.source.official.link' })}
+    </a>
+  ) : null;
+
+  // What following the official source means for this kind. Carried by the two
+  // places that talk about going back to it — the editor's tooltip and Reset —
+  // rather than sitting under the URL box, whose badge already names it.
+  const officialDescription = intl.formatMessage({
+    id: slot.officialDescriptionKey
+  });
+
+  const readContent = () =>
+    editorRef.current?.getValue?.() ?? formState.content;
+
+  const seedForm = (cfg: SourceConfig) => {
+    // Nothing configured shows the official address itself rather than an empty
+    // box: the server reads that address as "follow the official source", so
+    // what is on screen is what is in effect.
+    form.setFieldsValue({ url: cfg.custom?.url || officialFileUrl });
+    setRemoteEnabled(cfg.remote_enabled);
+    setFileHasContent(hasMeaningfulContent(cfg.custom?.content || ''));
+    setFormState({
+      sourceType:
+        cfg.custom?.source_type === SourceTypeValueMap.FILE
+          ? SourceTypeValueMap.FILE
+          : SourceTypeValueMap.URL,
+      content: cfg.custom?.content || slot.contentTemplate || '',
+      customHours: cfg.custom?.auto_update_hours || 0,
+      officialHours: cfg.official.auto_update_hours
+    });
+  };
+
+  // The slot is mounted with the drawer, so this runs once per open. A failed
+  // read leaves the form untouched rather than seeded from a placeholder, so
+  // there is nothing on screen for Save to write back over the real thing.
+  useEffect(() => {
+    const init = async () => {
+      const data = await load();
+      setLoadFailed(!data);
+      if (data) {
+        seedForm(data);
+      }
+    };
+    init();
+  }, []);
+
+  // The address rides the probe, which races the config load, so seeding may
+  // have run without it. Fill it in when it lands — never over a URL of the
+  // admin's own, and never over an empty box they cleared themselves
+  // (`urlValue` is deliberately not a dependency). A failed read is excluded
+  // for the same reason it skips `seedForm`: `config` is then the placeholder,
+  // whose null `custom` would otherwise read as "nothing configured" and put an
+  // address on screen that no read ever confirmed.
+  useEffect(() => {
+    if (
+      !loadFailed &&
+      officialFileUrl &&
+      !config.custom &&
+      !form.getFieldValue('url')
+    ) {
+      form.setFieldsValue({ url: officialFileUrl });
+    }
+  }, [officialFileUrl, config.custom, loadFailed]);
+
+  // Mirrors gpustack/server/sources/core.py: decidable without a request. An
+  // empty box is not an error here — it is how the official source is chosen.
+  const validateSourceUrl = (_: any, value: string) => {
+    if (!value?.trim()) {
+      return Promise.resolve();
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(value.trim());
+    } catch {
+      return Promise.reject(
+        new Error(intl.formatMessage({ id: 'common.source.url.scheme' }))
+      );
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return Promise.reject(
+        new Error(intl.formatMessage({ id: 'common.source.url.scheme' }))
+      );
+    }
+    if (parsed.username || parsed.password) {
+      return Promise.reject(
+        new Error(intl.formatMessage({ id: 'common.source.url.credentials' }))
+      );
+    }
+    if (!parsed.hostname) {
+      return Promise.reject(
+        new Error(intl.formatMessage({ id: 'common.source.url.host' }))
+      );
+    }
+    return Promise.resolve();
+  };
+
+  // The row moves two axes. The factory card only takes remote content out of
+  // service, leaving `sourceType` where it was — that is what says which
+  // source to park. A typed URL survives the File branch either way (the form
+  // is only hidden, never unmounted), and `readContent` mirrors the editor's
+  // text into state on the way out of it, falling back to state when the editor
+  // is not mounted at all.
+  const handleModeChange = (value: SlotMode) => {
+    const content = readContent();
+    setRemoteEnabled(value !== SourceTypeValueMap.BUILTIN);
+    setFormState({
+      ...formState,
+      content,
+      sourceType:
+        value === SourceTypeValueMap.BUILTIN ? formState.sourceType : value
+    });
+    setFileHasContent(hasMeaningfulContent(content || ''));
+  };
+
+  // Back to the default: the official address *is* the official source, so this
+  // puts it back rather than leaving an empty box — the change lands with Save
+  // like any other edit.
+  const handleReset = () => {
+    setAlert('');
+    form.setFieldsValue({ url: officialFileUrl });
+    editorRef.current?.setValue?.(slot.contentTemplate || '');
+    setFormState({ ...formState, content: slot.contentTemplate || '' });
+    setFileHasContent(false);
+  };
+
+  // The form carries unsaved edits vs the persisted config. The refetch button
+  // acts on what is *stored*, so it is blocked while the form is dirty — Save is
+  // what applies an edit, and Save fetches on its own.
+  const isDirty = (): boolean => {
+    if (remoteEnabled !== config.remote_enabled) {
+      return true;
+    }
+    if (formState.officialHours !== config.official.auto_update_hours) {
+      return true;
+    }
+    const custom = config.custom;
+    if (customConfigured !== !!custom) {
+      return true;
+    }
+    if (!custom) {
+      return false;
+    }
+    if (formState.sourceType !== custom.source_type) {
+      return true;
+    }
+    if (isUrlMode) {
+      return (
+        urlValue.trim() !== (custom.url || '') ||
+        formState.customHours !== (custom.auto_update_hours || 0)
+      );
+    }
+    return (formState.content || '') !== (custom.content || '');
+  };
+
+  const dirty = isDirty();
+  // A stored URL of the admin's re-reads itself; the official slot runs one
+  // round. Stored inline content has nothing to fetch, and a kind whose
+  // official updates are off stays out of the round by design — offering the
+  // button there would lie. Nothing is refreshed at all while fallen back.
+  const storedIsUrl = config.custom?.source_type === SourceTypeValueMap.URL;
+  const showRefetch = remoteEnabled && (config.custom ? storedIsUrl : true);
+  // A failed read rules it out on its own: `config` is then the placeholder,
+  // whose cadence of 12 would otherwise offer a refetch of a slot nothing is
+  // known about — under a banner saying exactly that.
+  const canRefetch =
+    !dirty &&
+    !loadFailed &&
+    (config.custom ? storedIsUrl : config.official.auto_update_hours > 0);
+  // A cadence belongs to something that gets re-read, and inline content never
+  // is. While that branch is still empty the cadence in play is the
+  // official one — true, but under a file editor it reads as if the file had an
+  // update schedule, so it stays in the URL branch where its subject is visible.
+  const showAutoUpdate = remoteEnabled && !isFileMode;
+
+  const buildPayload = async (): Promise<SourceConfigUpsert | null> => {
+    const base = {
+      remote_enabled: remoteEnabled,
+      official: { auto_update_hours: formState.officialHours }
+    };
+    // Falling back never deletes. The inputs are hidden while the factory card
+    // is selected, so an empty box there is a leftover rather than a choice just
+    // made — what is configured is kept, parked, for the way back. Dropping a
+    // source is done from an online card, where the box that says so is on
+    // screen.
+    if (!remoteEnabled && !customConfigured) {
+      const parked: CustomSourceUpsert | null = config.custom
+        ? {
+            source_type: config.custom.source_type,
+            url: config.custom.url,
+            content: config.custom.content,
+            auto_update_hours: config.custom.auto_update_hours
+          }
+        : null;
+      return { ...base, custom: parked };
+    }
+    if (isFileMode) {
+      const content = readContent();
+      return {
+        ...base,
+        custom: hasMeaningfulContent(content ?? '')
+          ? {
+              source_type: SourceTypeValueMap.FILE,
+              content,
+              // A file source has nothing to re-fetch.
+              auto_update_hours: 0
+            }
+          : null
+      };
+    }
+    // Empty, or the official address itself: both say "follow the official
+    // source", so neither is sent as a source of the admin's own.
+    if (!customConfigured) {
+      return { ...base, custom: null };
+    }
+    let values;
+    try {
+      values = await form.validateFields();
+    } catch {
+      // field errors render inline
+      return null;
+    }
+    return {
+      ...base,
+      custom: {
+        source_type: SourceTypeValueMap.URL,
+        url: values.url.trim(),
+        auto_update_hours: formState.customHours
+      }
+    };
+  };
+
+  const applyWrite = (payload: SourceConfigUpsert) =>
+    guard(() =>
+      run(async () => {
+        try {
+          setAlert('');
+          seedForm(await save(payload));
+          message.success(intl.formatMessage({ id: 'common.message.success' }));
+          onSaved();
+        } catch (error) {
+          setAlert(errorMessageOf(error));
+        }
+      })
+    );
+
+  const handleSave = async () => {
+    const payload = await buildPayload();
+    if (!payload) {
+      // Field errors render inline, and the branch that owns them may be the one
+      // the factory card is hiding — put it back on screen with the message.
+      setRemoteEnabled(true);
+      return;
+    }
+    applyWrite(payload);
+  };
+
+  const handleRefetch = async () => {
+    setReloading(true);
+    try {
+      setAlert('');
+      // One call whichever layer serves this kind — a stored URL of the admin's,
+      // or the official slot. Neither reaches the other two kinds, and a failure
+      // in either arrives as a rejected request rather than a per-kind entry in
+      // a round's report.
+      const { changed } = await reload();
+      onSaved();
+      message[changed ? 'success' : 'info'](
+        intl.formatMessage({
+          id: changed
+            ? 'common.message.success'
+            : 'common.source.sync.unchanged'
+        })
+      );
+    } catch (error) {
+      setAlert(errorMessageOf(error));
+      // The failure now lives on the probe too — surface it as the persistent
+      // banner alongside the last good content.
+      onSaved();
+    } finally {
+      setReloading(false);
+    }
+  };
+
+  return (
+    <Flex vertical gap={16}>
+      {/* A write that did not land wins over a read that did not: `alert` only
+          appears after an action just taken, while a failed read is the standing
+          condition underneath it. */}
+      {(alert || loadFailed) && (
+        <AlertBlockInfo
+          type="danger"
+          message={
+            alert || intl.formatMessage({ id: 'common.source.load.failed' })
+          }
+          ellipsis={false}
+          maxHeight={120}
+        ></AlertBlockInfo>
+      )}
+
+      {/* One row for the whole question of where the content comes from, and
+          everything below it describes the card that is selected. */}
+      <CardRadioGroup<SlotMode>
+        columns={slot.allowFile ? 3 : 2}
+        value={mode}
+        onChange={handleModeChange}
+        options={[
+          {
+            label: intl.formatMessage({ id: 'common.source.type.url' }),
+            description: intl.formatMessage({
+              id: 'common.source.type.url.desc'
+            }),
+            value: SourceTypeValueMap.URL
+          },
+          ...(slot.allowFile
+            ? [
+                {
+                  label: intl.formatMessage({ id: 'common.source.type.file' }),
+                  description: intl.formatMessage({
+                    id: 'common.source.type.file.desc'
+                  }),
+                  value: SourceTypeValueMap.FILE
+                }
+              ]
+            : []),
+          {
+            label: intl.formatMessage({ id: 'common.source.type.builtin' }),
+            description: intl.formatMessage({
+              id: 'common.source.type.builtin.desc'
+            }),
+            value: SourceTypeValueMap.BUILTIN
+          }
+        ]}
+      />
+
+      {/* kept mounted while another branch shows so a typed URL survives */}
+      <Form
+        form={form}
+        layout="vertical"
+        onValuesChange={() => setAlert('')}
+        style={{ display: remoteEnabled && isUrlMode ? 'block' : 'none' }}
+      >
+        <Form.Item
+          name="url"
+          style={{ marginBottom: 0 }}
+          rules={[{ validator: validateSourceUrl }]}
+        >
+          <CInput.Input
+            label={intl.formatMessage({ id: 'common.source.url' })}
+            description={intl.formatMessage({ id: 'common.source.empty.hint' })}
+            // Beside the label rather than after the box: it says what the
+            // address *is*, which belongs with the field's name and not with
+            // the value. Editing it into a URL of your own drops the badge
+            // with the same keystroke that drops the official source. Same
+            // component the drawer tags its panels with.
+            labelExtra={
+              urlIsOfficial ? (
+                <TextAttribute className={cx('m-l-4', styles.officialTag)}>
+                  {intl.formatMessage({ id: 'common.source.tag.official' })}
+                </TextAttribute>
+              ) : null
+            }
+          ></CInput.Input>
+        </Form.Item>
+      </Form>
+
+      {remoteEnabled && isFileMode && (
+        <YamlEditor
+          ref={editorRef}
+          // The editor's header already holds a label and the Import button, so
+          // the guidance rides there as a tooltip instead of adding one more
+          // line of grey text under a 320px box.
+          title={
+            <>
+              {intl.formatMessage({ id: 'common.source.content' })}
+              <Tooltip
+                title={
+                  <Flex vertical gap={4}>
+                    <span>
+                      {intl.formatMessage({ id: 'common.source.content.hint' })}
+                    </span>
+                    <span>
+                      {intl.formatMessage(
+                        { id: 'common.source.empty.hint.file' },
+                        { description: officialDescription }
+                      )}
+                    </span>
+                  </Flex>
+                }
+              >
+                <QuestionCircleOutlined
+                  className={cx('m-l-4', styles.hintIcon)}
+                />
+              </Tooltip>
+              {officialFileLink}
+            </>
+          }
+          height={320}
+          value={formState.content}
+          isDarkTheme={isDarkTheme}
+          onChange={(text) =>
+            setFileHasContent(hasMeaningfulContent(text || ''))
+          }
+        ></YamlEditor>
+      )}
+
+      {/* The way back to the default, as something to press: the same rule the
+          input's tooltip states, but it only makes sense once there is
+          something to undo. */}
+      {remoteEnabled && customConfigured && (
+        <Flex className={styles.linkRow}>
+          <Tooltip
+            title={intl.formatMessage(
+              { id: 'common.source.reset.tip' },
+              { description: officialDescription }
+            )}
+          >
+            <Button
+              type="link"
+              size="small"
+              icon={<UndoOutlined />}
+              onClick={handleReset}
+            >
+              {intl.formatMessage({ id: 'common.source.reset' })}
+            </Button>
+          </Tooltip>
+        </Flex>
+      )}
+
+      {showAutoUpdate && (
+        <AutoUpdateField
+          description={intl.formatMessage({
+            id: customConfigured
+              ? 'common.source.autoUpdate.custom.tip'
+              : 'common.source.autoUpdate.official.tip'
+          })}
+          hours={
+            customConfigured ? formState.customHours : formState.officialHours
+          }
+          onChange={(hours) =>
+            setFormState(
+              customConfigured
+                ? { ...formState, customHours: hours }
+                : { ...formState, officialHours: hours }
+            )
+          }
+        ></AutoUpdateField>
+      )}
+
+      {status?.updated_at && remoteEnabled && (
+        <span className={styles.metaLine}>
+          {intl.formatMessage(
+            { id: 'common.source.lastUpdated' },
+            { time: dayjs(status.updated_at).format('YYYY-MM-DD HH:mm:ss') }
+          )}
+        </span>
+      )}
+
+      {remoteEnabled && status?.error && (
+        <AlertBlockInfo
+          type="warning"
+          message={status.error}
+          ellipsis={false}
+          maxHeight={120}
+        ></AlertBlockInfo>
+      )}
+
+      <Flex align="center" gap={8}>
+        {showRefetch && (
+          <Tooltip
+            title={
+              dirty
+                ? intl.formatMessage({ id: 'common.source.sync.hint.dirty' })
+                : undefined
+            }
+          >
+            <span style={{ display: 'inline-flex' }}>
+              <Button
+                color="primary"
+                variant="filled"
+                icon={<SyncOutlined />}
+                disabled={!canRefetch}
+                loading={reloading}
+                onClick={handleRefetch}
+              >
+                {/* One wording, two keys: the branches reach different
+                    endpoints (see `handleRefetch`) and stay separately
+                    translatable. */}
+                {intl.formatMessage({
+                  id: config.custom
+                    ? 'common.source.sync.custom'
+                    : 'common.source.sync.official'
+                })}
+              </Button>
+            </span>
+          </Tooltip>
+        )}
+        {/* Pushed to the far end by its own margin rather than by
+            `space-between`, which needs a sibling to push against: antd
+            collapses an empty Flex (`&:empty { display: none }`), so a wrapper
+            standing in for the absent refetch button would not hold the space. */}
+        {/* Nothing on screen came from the server when the read failed, so
+            there is no configuration here to write. */}
+        <Button
+          type="primary"
+          loading={submitting}
+          disabled={loadFailed}
+          style={{ marginInlineStart: 'auto' }}
+          onClick={handleSave}
+        >
+          {intl.formatMessage({ id: 'common.source.save' })}
+        </Button>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default SourceSlotForm;

--- a/src/pages/_components/source-config/slot-form.tsx
+++ b/src/pages/_components/source-config/slot-form.tsx
@@ -10,15 +10,17 @@ import {
   CheckboxField,
   Input as CInput,
   InputNumber as CInputNumber,
+  ModalFooter,
   TextAttribute,
   useSubmitLock
 } from '@gpustack/core-ui';
 import { YamlEditor } from '@gpustack/core-ui/yaml-editor';
 import { useIntl } from '@umijs/max';
-import { Button, Flex, Form, message, Tooltip } from 'antd';
+import { Alert, Button, Flex, Form, message, Tooltip } from 'antd';
 import { createStyles } from 'antd-style';
 import dayjs from 'dayjs';
 import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { SourceTypeValueMap } from './config';
 import type {
   CustomSourceUpsert,
@@ -131,6 +133,12 @@ interface SourceSlotFormProps {
   otaServerUrl: string;
   // A write landed, so the probe and the list behind the drawer are stale.
   onSaved: () => void;
+  // Closes the drawer, for the Cancel this form's footer carries.
+  onCancel: () => void;
+  // The drawer's fixed bottom bar, to render this form's buttons into. Null
+  // while another tab has it: every tab stays mounted, so the bar is handed to
+  // one of them at a time.
+  footerContainer: HTMLElement | null;
 }
 
 /**
@@ -159,7 +167,9 @@ const SourceSlotForm: React.FC<SourceSlotFormProps> = ({
   slot,
   status,
   otaServerUrl,
-  onSaved
+  onSaved,
+  onCancel,
+  footerContainer
 }) => {
   const intl = useIntl();
   const { styles, cx } = useStyles();
@@ -522,236 +532,269 @@ const SourceSlotForm: React.FC<SourceSlotFormProps> = ({
     }
   };
 
+  // Acts on what is *stored*, so it is blocked while the form is dirty — Save is
+  // what applies an edit, and Save fetches on its own.
+  const refetchButton = (
+    <Tooltip
+      title={
+        dirty
+          ? intl.formatMessage({ id: 'common.source.sync.hint.dirty' })
+          : undefined
+      }
+    >
+      <span style={{ display: 'inline-flex' }}>
+        {/* Default styling, like Cancel beside it: re-reading a source the form
+            already points at is not the action this drawer is here for. */}
+        <Button
+          icon={<SyncOutlined />}
+          disabled={!canRefetch}
+          loading={reloading}
+          onClick={handleRefetch}
+        >
+          {/* One wording, two keys: the branches reach different endpoints (see
+              `handleRefetch`) and stay separately translatable. */}
+          {intl.formatMessage({
+            id: config.custom
+              ? 'common.source.sync.custom'
+              : 'common.source.sync.official'
+          })}
+        </Button>
+      </span>
+    </Tooltip>
+  );
+
   return (
-    <Flex vertical gap={16}>
-      {/* A write that did not land wins over a read that did not: `alert` only
+    <>
+      <Flex vertical gap={16}>
+        {/* A write that did not land wins over a read that did not: `alert` only
           appears after an action just taken, while a failed read is the standing
           condition underneath it. */}
-      {(alert || loadFailed) && (
-        <AlertBlockInfo
-          type="danger"
-          message={
-            alert || intl.formatMessage({ id: 'common.source.load.failed' })
-          }
-          ellipsis={false}
-          maxHeight={120}
-        ></AlertBlockInfo>
-      )}
-
-      {/* One row for the whole question of where the content comes from, and
-          everything below it describes the card that is selected. */}
-      <CardRadioGroup<SlotMode>
-        columns={slot.allowFile ? 3 : 2}
-        value={mode}
-        onChange={handleModeChange}
-        options={[
-          {
-            label: intl.formatMessage({ id: 'common.source.type.url' }),
-            description: intl.formatMessage({
-              id: 'common.source.type.url.desc'
-            }),
-            value: SourceTypeValueMap.URL
-          },
-          ...(slot.allowFile
-            ? [
-                {
-                  label: intl.formatMessage({ id: 'common.source.type.file' }),
-                  description: intl.formatMessage({
-                    id: 'common.source.type.file.desc'
-                  }),
-                  value: SourceTypeValueMap.FILE
-                }
-              ]
-            : []),
-          {
-            label: intl.formatMessage({ id: 'common.source.type.builtin' }),
-            description: intl.formatMessage({
-              id: 'common.source.type.builtin.desc'
-            }),
-            value: SourceTypeValueMap.BUILTIN
-          }
-        ]}
-      />
-
-      {/* kept mounted while another branch shows so a typed URL survives */}
-      <Form
-        form={form}
-        layout="vertical"
-        onValuesChange={() => setAlert('')}
-        style={{ display: remoteEnabled && isUrlMode ? 'block' : 'none' }}
-      >
-        <Form.Item
-          name="url"
-          style={{ marginBottom: 0 }}
-          rules={[{ validator: validateSourceUrl }]}
-        >
-          <CInput.Input
-            label={intl.formatMessage({ id: 'common.source.url' })}
-            description={intl.formatMessage({ id: 'common.source.empty.hint' })}
-            // Beside the label rather than after the box: it says what the
-            // address *is*, which belongs with the field's name and not with
-            // the value. Editing it into a URL of your own drops the badge
-            // with the same keystroke that drops the official source. Same
-            // component the drawer tags its panels with.
-            labelExtra={
-              urlIsOfficial ? (
-                <TextAttribute className={cx('m-l-4', styles.officialTag)}>
-                  {intl.formatMessage({ id: 'common.source.tag.official' })}
-                </TextAttribute>
-              ) : null
+        {(alert || loadFailed) && (
+          <AlertBlockInfo
+            type="danger"
+            message={
+              alert || intl.formatMessage({ id: 'common.source.load.failed' })
             }
-          ></CInput.Input>
-        </Form.Item>
-      </Form>
+            ellipsis={false}
+            maxHeight={120}
+          ></AlertBlockInfo>
+        )}
 
-      {remoteEnabled && isFileMode && (
-        <YamlEditor
-          ref={editorRef}
-          // The editor's header already holds a label and the Import button, so
-          // the guidance rides there as a tooltip instead of adding one more
-          // line of grey text under a 320px box.
-          title={
-            <>
-              {intl.formatMessage({ id: 'common.source.content' })}
-              <Tooltip
-                title={
-                  <Flex vertical gap={4}>
-                    <span>
-                      {intl.formatMessage({ id: 'common.source.content.hint' })}
-                    </span>
-                    <span>
-                      {intl.formatMessage(
-                        { id: 'common.source.empty.hint.file' },
-                        { description: officialDescription }
-                      )}
-                    </span>
-                  </Flex>
-                }
-              >
-                <QuestionCircleOutlined
-                  className={cx('m-l-4', styles.hintIcon)}
-                />
-              </Tooltip>
-              {officialFileLink}
-            </>
-          }
-          height={320}
-          value={formState.content}
-          isDarkTheme={isDarkTheme}
-          onChange={(text) =>
-            setFileHasContent(hasMeaningfulContent(text || ''))
-          }
-        ></YamlEditor>
-      )}
+        {/* One row for the whole question of where the content comes from, and
+          everything below it describes the card that is selected. */}
+        <CardRadioGroup<SlotMode>
+          // Three columns whatever this slot offers, so a card is always a third
+          // of the row: the two a URL-only slot shows would otherwise stretch
+          // over half the width each and come out long and flat.
+          columns={3}
+          value={mode}
+          onChange={handleModeChange}
+          // Selection reads off the radio and the border; a tinted fill on top of
+          // both is a third signal for the same fact.
+          ghost
+          // A card holds one line of text, so its title is body text rather than
+          // the heading the component sizes it as.
+          styles={{ title: { fontSize: 'var(--font-size-base)' } }}
+          options={[
+            {
+              label: intl.formatMessage({ id: 'common.source.type.url' }),
+              value: SourceTypeValueMap.URL
+            },
+            ...(slot.allowFile
+              ? [
+                  {
+                    label: intl.formatMessage({
+                      id: 'common.source.type.file'
+                    }),
+                    value: SourceTypeValueMap.FILE
+                  }
+                ]
+              : []),
+            {
+              label: intl.formatMessage({ id: 'common.source.type.builtin' }),
+              value: SourceTypeValueMap.BUILTIN
+            }
+          ]}
+        />
 
-      {/* The way back to the default, as something to press: the same rule the
+        {/* The factory card hides every input, so it is the one card whose
+          consequence has nowhere else to show. antd's own Alert rather than
+          `AlertBlockInfo`, whose palette starts at warning — an informational
+          banner there comes out uncoloured. */}
+        {!remoteEnabled && (
+          <Alert
+            type="info"
+            showIcon
+            message={intl.formatMessage({
+              id: 'common.source.type.builtin.desc'
+            })}
+          ></Alert>
+        )}
+
+        {/* kept mounted while another branch shows so a typed URL survives */}
+        <Form
+          form={form}
+          layout="vertical"
+          onValuesChange={() => setAlert('')}
+          style={{ display: remoteEnabled && isUrlMode ? 'block' : 'none' }}
+        >
+          <Form.Item
+            name="url"
+            style={{ marginBottom: 0 }}
+            rules={[{ validator: validateSourceUrl }]}
+          >
+            <CInput.Input
+              label={intl.formatMessage({ id: 'common.source.url' })}
+              description={intl.formatMessage({
+                id: 'common.source.empty.hint'
+              })}
+              // Beside the label rather than after the box: it says what the
+              // address *is*, which belongs with the field's name and not with
+              // the value. Editing it into a URL of your own drops the badge
+              // with the same keystroke that drops the official source. Same
+              // component the drawer tags its panels with.
+              labelExtra={
+                urlIsOfficial ? (
+                  <TextAttribute className={cx('m-l-4', styles.officialTag)}>
+                    {intl.formatMessage({ id: 'common.source.tag.official' })}
+                  </TextAttribute>
+                ) : null
+              }
+            ></CInput.Input>
+          </Form.Item>
+        </Form>
+
+        {remoteEnabled && isFileMode && (
+          <YamlEditor
+            ref={editorRef}
+            // The editor's header already holds a label and the Import button, so
+            // the guidance rides there as a tooltip instead of adding one more
+            // line of grey text under a 320px box.
+            title={
+              <>
+                {intl.formatMessage({ id: 'common.source.content' })}
+                <Tooltip
+                  title={
+                    <Flex vertical gap={4}>
+                      <span>
+                        {intl.formatMessage({
+                          id: 'common.source.content.hint'
+                        })}
+                      </span>
+                      <span>
+                        {intl.formatMessage(
+                          { id: 'common.source.empty.hint.file' },
+                          { description: officialDescription }
+                        )}
+                      </span>
+                    </Flex>
+                  }
+                >
+                  <QuestionCircleOutlined
+                    className={cx('m-l-4', styles.hintIcon)}
+                  />
+                </Tooltip>
+                {officialFileLink}
+              </>
+            }
+            height={320}
+            value={formState.content}
+            isDarkTheme={isDarkTheme}
+            onChange={(text) =>
+              setFileHasContent(hasMeaningfulContent(text || ''))
+            }
+          ></YamlEditor>
+        )}
+
+        {/* The way back to the default, as something to press: the same rule the
           input's tooltip states, but it only makes sense once there is
           something to undo. */}
-      {remoteEnabled && customConfigured && (
-        <Flex className={styles.linkRow}>
-          <Tooltip
-            title={intl.formatMessage(
-              { id: 'common.source.reset.tip' },
-              { description: officialDescription }
-            )}
-          >
-            <Button
-              type="link"
-              size="small"
-              icon={<UndoOutlined />}
-              onClick={handleReset}
+        {remoteEnabled && customConfigured && (
+          <Flex className={styles.linkRow}>
+            <Tooltip
+              title={intl.formatMessage(
+                { id: 'common.source.reset.tip' },
+                { description: officialDescription }
+              )}
             >
-              {intl.formatMessage({ id: 'common.source.reset' })}
-            </Button>
-          </Tooltip>
-        </Flex>
-      )}
-
-      {showAutoUpdate && (
-        <AutoUpdateField
-          description={intl.formatMessage({
-            id: customConfigured
-              ? 'common.source.autoUpdate.custom.tip'
-              : 'common.source.autoUpdate.official.tip'
-          })}
-          hours={
-            customConfigured ? formState.customHours : formState.officialHours
-          }
-          onChange={(hours) =>
-            setFormState(
-              customConfigured
-                ? { ...formState, customHours: hours }
-                : { ...formState, officialHours: hours }
-            )
-          }
-        ></AutoUpdateField>
-      )}
-
-      {status?.updated_at && remoteEnabled && (
-        <span className={styles.metaLine}>
-          {intl.formatMessage(
-            { id: 'common.source.lastUpdated' },
-            { time: dayjs(status.updated_at).format('YYYY-MM-DD HH:mm:ss') }
-          )}
-        </span>
-      )}
-
-      {remoteEnabled && status?.error && (
-        <AlertBlockInfo
-          type="warning"
-          message={status.error}
-          ellipsis={false}
-          maxHeight={120}
-        ></AlertBlockInfo>
-      )}
-
-      <Flex align="center" gap={8}>
-        {showRefetch && (
-          <Tooltip
-            title={
-              dirty
-                ? intl.formatMessage({ id: 'common.source.sync.hint.dirty' })
-                : undefined
-            }
-          >
-            <span style={{ display: 'inline-flex' }}>
               <Button
-                color="primary"
-                variant="filled"
-                icon={<SyncOutlined />}
-                disabled={!canRefetch}
-                loading={reloading}
-                onClick={handleRefetch}
+                type="link"
+                size="small"
+                icon={<UndoOutlined />}
+                onClick={handleReset}
               >
-                {/* One wording, two keys: the branches reach different
-                    endpoints (see `handleRefetch`) and stay separately
-                    translatable. */}
-                {intl.formatMessage({
-                  id: config.custom
-                    ? 'common.source.sync.custom'
-                    : 'common.source.sync.official'
-                })}
+                {intl.formatMessage({ id: 'common.source.reset' })}
               </Button>
-            </span>
-          </Tooltip>
+            </Tooltip>
+          </Flex>
         )}
-        {/* Pushed to the far end by its own margin rather than by
-            `space-between`, which needs a sibling to push against: antd
-            collapses an empty Flex (`&:empty { display: none }`), so a wrapper
-            standing in for the absent refetch button would not hold the space. */}
-        {/* Nothing on screen came from the server when the read failed, so
-            there is no configuration here to write. */}
-        <Button
-          type="primary"
-          loading={submitting}
-          disabled={loadFailed}
-          style={{ marginInlineStart: 'auto' }}
-          onClick={handleSave}
-        >
-          {intl.formatMessage({ id: 'common.source.save' })}
-        </Button>
+
+        {showAutoUpdate && (
+          <AutoUpdateField
+            description={intl.formatMessage({
+              id: customConfigured
+                ? 'common.source.autoUpdate.custom.tip'
+                : 'common.source.autoUpdate.official.tip'
+            })}
+            hours={
+              customConfigured ? formState.customHours : formState.officialHours
+            }
+            onChange={(hours) =>
+              setFormState(
+                customConfigured
+                  ? { ...formState, customHours: hours }
+                  : { ...formState, officialHours: hours }
+              )
+            }
+          ></AutoUpdateField>
+        )}
+
+        {status?.updated_at && remoteEnabled && (
+          <span className={styles.metaLine}>
+            {intl.formatMessage(
+              { id: 'common.source.lastUpdated' },
+              { time: dayjs(status.updated_at).format('YYYY-MM-DD HH:mm:ss') }
+            )}
+          </span>
+        )}
+
+        {remoteEnabled && status?.error && (
+          <AlertBlockInfo
+            type="warning"
+            message={status.error}
+            ellipsis={false}
+            maxHeight={120}
+          ></AlertBlockInfo>
+        )}
       </Flex>
-    </Flex>
+
+      {/* The buttons belong to this form — only their place is the drawer's, so
+          they land in the fixed bar rather than at the end of the scrolling
+          content. Rendered from here so every state they read (dirty, the
+          in-flight write, a failed load) stays where it is produced, and the
+          bar holds the active tab's buttons alone. */}
+      {footerContainer &&
+        createPortal(
+          <ModalFooter
+            onCancel={onCancel}
+            onOk={handleSave}
+            loading={submitting}
+            // Nothing on screen came from the server when the read failed, so
+            // there is no configuration here to write.
+            okBtnProps={{ disabled: loadFailed }}
+            // The far end of the bar: `description` is the slot on the other
+            // side of the footer's `space-between`, which keeps this away from
+            // the two buttons that close the drawer.
+            description={showRefetch ? refetchButton : undefined}
+            // On the bar itself rather than on the buttons, so the padding is
+            // there for both ends. Same figures as the footer FormDrawer builds
+            // when it is left to its own (`core-ui/form-drawer`), so this
+            // drawer's bar lines up with every other one.
+            styles={{ wrapper: { padding: '16px 24px 8px' } }}
+          ></ModalFooter>,
+          footerContainer
+        )}
+    </>
   );
 };
 

--- a/src/pages/_components/source-config/types.ts
+++ b/src/pages/_components/source-config/types.ts
@@ -11,8 +11,8 @@ export type SourceType = 'file' | 'url';
 // stable id a scope's slot binds its probe status to.
 export type SourceProbeKind =
   | 'catalog'
-  | 'community_backend'
-  | 'built_in_backend';
+  | 'community-backend'
+  | 'built-in-backend';
 
 // The admin's own source. Setting one *replaces* both the packaged baseline
 // and the official slot — the layers never stack — so this is the whole content
@@ -122,9 +122,12 @@ export interface SourceSlotConfig {
   // Probe kind, panel key, and the path segment its own endpoints sit under —
   // which is why a slot needs no API wiring of its own.
   kind: SourceProbeKind;
-  // Panel header. Only a multi-slot scope needs one — a single-slot scope is
+  // Tab label. Only a multi-slot scope needs one — a single-slot scope is
   // already named by the drawer title.
   titleKey?: string;
+  // IconFont name beside that label, for the same reason: it only shows where
+  // there is another tab to tell this one apart from.
+  iconType?: string;
   // Whether this slot accepts an inline FILE (catalog only) — the third card in
   // its row; URL-only slots show two.
   allowFile: boolean;

--- a/src/pages/_components/source-config/types.ts
+++ b/src/pages/_components/source-config/types.ts
@@ -1,0 +1,145 @@
+// Types for the source configuration UI. One endpoint family serves all three
+// kinds of content — `/ota-sources/{kind}` for the model catalog, the community
+// backend library and the built-in backend versions — so these types are shared
+// rather than per-feed.
+
+// The two configurable members of `SourceTypeValueMap` (see `./config`): the
+// platform writes `builtin` / `official` itself, so neither is ever sent.
+export type SourceType = 'file' | 'url';
+
+// The refresher's per-kind key (`OFFICIAL_KINDS` in the backend). Also the
+// stable id a scope's slot binds its probe status to.
+export type SourceProbeKind =
+  | 'catalog'
+  | 'community_backend'
+  | 'built_in_backend';
+
+// The admin's own source. Setting one *replaces* both the packaged baseline
+// and the official slot — the layers never stack — so this is the whole content
+// for its kind. `content` is the stored, normalized text, kept so a saved FILE
+// source can be edited again (there is no URL to re-fetch it from).
+export interface CustomSourceState {
+  source_type: SourceType;
+  url?: string | null;
+  content?: string | null;
+  // Auto-refresh cadence in hours (0 = off); only a URL source can opt in.
+  auto_update_hours: number;
+  // A URL is fetched at save / reload time — when that content was taken.
+  updated_at?: string | null;
+  content_hash?: string | null;
+}
+
+// The platform's remote slot. Its content is written by the refresh task, so
+// the cadence is the only part an admin sets; the rest is state shown beside it.
+export interface OfficialSourceState {
+  // 0 = official updates are off for this kind.
+  auto_update_hours: number;
+  // Derived, not a setting: false while a custom source replaces the slot, or
+  // while remote content is out of service (`remote_enabled`).
+  enabled: boolean;
+  updated_at?: string | null;
+  content_hash?: string | null;
+}
+
+// GET /ota-sources/{kind}. One object carries a kind's whole configuration, so
+// the screen loads it in one request. `custom: null` means the official source
+// serves the content; `remote_enabled: false` means neither does — the packaged
+// baseline serves on its own, with both sources parked for the way back.
+export interface SourceConfig {
+  remote_enabled: boolean;
+  custom?: CustomSourceState | null;
+  official: OfficialSourceState;
+}
+
+export interface CustomSourceUpsert {
+  source_type: SourceType;
+  content?: string | null;
+  url?: string | null;
+  auto_update_hours: number;
+}
+
+// PUT /ota-sources/{kind}. A full replacement of the configuration, so the
+// screen saves it in one request: `custom: null` *is* the switch back to the
+// official source, and a URL is fetched server-side here, which makes saving a
+// re-sync.
+export interface SourceConfigUpsert {
+  // False takes remote content out of service without discarding it: a
+  // configured source is parked rather than deleted, and parking never
+  // re-reads a URL — the fall-back has to work when that URL is the problem.
+  remote_enabled: boolean;
+  custom: CustomSourceUpsert | null;
+  // The server accepts nothing but the cadence here (`extra="forbid"`): the
+  // official content, its URL and its hashes belong to the refresh task.
+  official: { auto_update_hours: number };
+}
+
+// PUT / POST reload. `changed` is false when the new text hashed the same as
+// the stored one: nothing was written and no reconcile ran.
+export interface SourceWriteResult extends SourceConfig {
+  changed: boolean;
+}
+
+// GET /source-probe → `kinds[kind]`: the *active* remote source of a kind (the
+// custom row when it masks OFFICIAL, else the OFFICIAL slot). This is the only
+// place the leader-only state lives — the resolved ref and the last refresh
+// error.
+export interface SourceKindStatus {
+  source_type?: string | null;
+  url?: string | null;
+  official_masked: boolean;
+  // Whether any remote layer serves this kind. False is the fall-back state: the
+  // packaged baseline alone, with the sources parked.
+  remote_enabled: boolean;
+  auto_update_hours: number;
+  // The file this kind is published as on the OTA server. Joined onto
+  // `ota_server_url` it links straight at the official file — the starting point for a
+  // custom source, which replaces exactly that file. Reported whichever
+  // source is active, so the link is there while a custom source is configured.
+  filename: string;
+  remote_hash?: string | null;
+  content_hash?: string | null;
+  updated_at?: string | null;
+  // The last refresh failure, kept while the stored content is still served.
+  // Populated only on the leader.
+  error?: string | null;
+}
+
+export interface SourceProbeStatus {
+  // The directory the official files are published under, after any server-side
+  // OTA server override. Join it with a kind's `filename` to download.
+  ota_server_url: string;
+  // The round-level fields (`error`, `refreshed_at`) are populated only on the
+  // server that runs the refresher; a standby reports the DB-backed fields only.
+  refreshing_on_this_server: boolean;
+  refreshed_at?: string | null;
+  kinds: Partial<Record<SourceProbeKind, SourceKindStatus>>;
+}
+
+// One kind of content the drawer can configure. A scope has one slot (catalog)
+// or two (the backend drawer stacks the built-in and community sources as
+// independently expandable panels).
+export interface SourceSlotConfig {
+  // Probe kind, panel key, and the path segment its own endpoints sit under —
+  // which is why a slot needs no API wiring of its own.
+  kind: SourceProbeKind;
+  // Panel header. Only a multi-slot scope needs one — a single-slot scope is
+  // already named by the drawer title.
+  titleKey?: string;
+  // Whether this slot accepts an inline FILE (catalog only) — the third card in
+  // its row; URL-only slots show two.
+  allowFile: boolean;
+  // What this kind's official source follows, shown as the hint beside the
+  // input — leaving that input empty is what follows it.
+  officialDescriptionKey: string;
+  // Commented YAML seeded into the editor when a FILE slot has no content yet.
+  contentTemplate?: string;
+}
+
+// Per-scope wiring: the drawer title, its slots, and the shared probe endpoint.
+export interface SourceScopeConfig {
+  // Drawer title, e.g. "Backend Source".
+  titleKey: string;
+  slots: SourceSlotConfig[];
+  // GET /source-probe. Shared across scopes: one call reports every kind.
+  probe: () => Promise<SourceProbeStatus>;
+}

--- a/src/pages/_components/source-config/use-source-config.ts
+++ b/src/pages/_components/source-config/use-source-config.ts
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { queryOtaSource, reloadOtaSource, updateOtaSource } from './apis';
+import type {
+  SourceConfig,
+  SourceConfigUpsert,
+  SourceProbeKind,
+  SourceProbeStatus,
+  SourceScopeConfig,
+  SourceWriteResult
+} from './types';
+
+// The cadence the server creates an official slot with. Only a placeholder here:
+// the switch turns official updates back on at this value when the stored one
+// is 0, and it stands in until the first GET answers.
+export const OFFICIAL_DEFAULT_HOURS = 12;
+
+// What a slot reports before its first fetch: no custom source, official on.
+const EMPTY_CONFIG: SourceConfig = {
+  remote_enabled: true,
+  custom: null,
+  official: {
+    auto_update_hours: OFFICIAL_DEFAULT_HOURS,
+    enabled: true,
+    updated_at: null,
+    content_hash: null
+  }
+};
+
+/**
+ * One slot's stored configuration — both halves of it, since the server carries
+ * `custom` and `official` in a single object and replaces both in one write.
+ *
+ * Every write re-resolves the source server-side (a URL is fetched once per
+ * PUT), so `save` is also the re-sync action and `reload` is the cheaper variant
+ * that reuses whatever the kind already points at. Both can come back 400 with
+ * the reason; that message is thrown to the caller, which renders it inline.
+ *
+ * Addressed by `kind` alone — the endpoints are one family, so there is nothing
+ * per-slot left to inject.
+ */
+export const useSlotConfig = (kind: SourceProbeKind) => {
+  const [config, setConfig] = useState<SourceConfig>(EMPTY_CONFIG);
+
+  // Returns what it just fetched so the caller can seed the form from it
+  // without waiting for the state to land. `null` says the read failed, which
+  // the caller has to tell apart from a slot that is genuinely unconfigured:
+  // seeding the form from a placeholder would put values on screen that were
+  // never stored, and Save would write them over whatever is really there.
+  const load = async (): Promise<SourceConfig | null> => {
+    try {
+      const data = await queryOtaSource(kind);
+      setConfig(data);
+      return data;
+    } catch {
+      // surfaced by the global request error handler
+      return null;
+    }
+  };
+
+  const save = async (data: SourceConfigUpsert) => {
+    const result = await updateOtaSource(kind, data);
+    setConfig(result);
+    return result;
+  };
+
+  // Refresh this kind now, from whichever layer serves it. `changed: false`
+  // means the document hashed the same, so nothing was written.
+  const reload = async (): Promise<SourceWriteResult> => {
+    const result = await reloadOtaSource(kind);
+    setConfig(result);
+    return result;
+  };
+
+  return { config, load, save, reload };
+};
+
+/**
+ * The refresher's status. One call reports every kind, so the drawer fetches it
+ * once and hands each slot its own entry — that is where a slot's leader-only
+ * state lives (the resolved ref, the last failed refresh) plus the OTA server
+ * URL the official file download link is built from.
+ */
+export const useProbeStatus = (probe: SourceScopeConfig['probe']) => {
+  const [probeStatus, setProbeStatus] = useState<SourceProbeStatus | null>(
+    null
+  );
+
+  const loadProbe = async () => {
+    try {
+      const status = await probe();
+      setProbeStatus(status);
+      return status;
+    } catch {
+      // The last good status stands. This runs again after every save and
+      // refetch, and the address it carries is what tells the form that the
+      // URL in the box is the official file's own: dropping it on a failed
+      // round would leave that same URL reading as one of the admin's own,
+      // and the next Save would send it as one.
+      return null;
+    }
+  };
+
+  return { probeStatus, loadProbe };
+};

--- a/src/pages/backends/apis/index.ts
+++ b/src/pages/backends/apis/index.ts
@@ -52,3 +52,6 @@ export async function updateBackendFromYAML(
     data: params.data
   });
 }
+
+// Both kinds of backend content are configured through the shared OTA source
+// endpoints — see `@/pages/_components/source-config/apis`.

--- a/src/pages/backends/components/backend-source-entry.tsx
+++ b/src/pages/backends/components/backend-source-entry.tsx
@@ -5,21 +5,27 @@ import React from 'react';
 
 // Two URL-only kinds of content, each with its own official source and its own
 // configuration: the built-in backend versions and the community backend
-// library. They stack as panels that expand independently — configuring one
-// says nothing about the other. Built-in is the first (open) panel.
+// library. They sit behind a tab bar — configuring one says nothing about the
+// other. Built-in is the tab that opens.
 const backendSourceScope: SourceScopeConfig = {
   titleKey: 'backend.source.title',
   probe: querySourceProbe,
   slots: [
     {
-      kind: 'built_in_backend',
+      kind: 'built-in-backend',
       titleKey: 'backend.source.builtin.title',
+      // What this kind is a list of: the image versions the built-in backends
+      // are published at.
+      iconType: 'icon-version',
       allowFile: false,
       officialDescriptionKey: 'backend.source.builtin.official'
     },
     {
-      kind: 'community_backend',
+      kind: 'community-backend',
       titleKey: 'backend.source.community.title',
+      // The same icon the Add menu marks a community backend with
+      // (`hooks/use-create-backend.tsx`).
+      iconType: 'icon-public',
       allowFile: false,
       officialDescriptionKey: 'backend.source.community.official'
     }

--- a/src/pages/backends/components/backend-source-entry.tsx
+++ b/src/pages/backends/components/backend-source-entry.tsx
@@ -1,0 +1,33 @@
+import SourceConfigEntry from '@/pages/_components/source-config';
+import { querySourceProbe } from '@/pages/_components/source-config/probe';
+import type { SourceScopeConfig } from '@/pages/_components/source-config/types';
+import React from 'react';
+
+// Two URL-only kinds of content, each with its own official source and its own
+// configuration: the built-in backend versions and the community backend
+// library. They stack as panels that expand independently — configuring one
+// says nothing about the other. Built-in is the first (open) panel.
+const backendSourceScope: SourceScopeConfig = {
+  titleKey: 'backend.source.title',
+  probe: querySourceProbe,
+  slots: [
+    {
+      kind: 'built_in_backend',
+      titleKey: 'backend.source.builtin.title',
+      allowFile: false,
+      officialDescriptionKey: 'backend.source.builtin.official'
+    },
+    {
+      kind: 'community_backend',
+      titleKey: 'backend.source.community.title',
+      allowFile: false,
+      officialDescriptionKey: 'backend.source.community.official'
+    }
+  ]
+};
+
+const BackendSourceEntry: React.FC<{ onSaved?: () => void }> = ({
+  onSaved
+}) => <SourceConfigEntry config={backendSourceScope} onSaved={onSaved} />;
+
+export default BackendSourceEntry;

--- a/src/pages/backends/components/right-actions.tsx
+++ b/src/pages/backends/components/right-actions.tsx
@@ -1,0 +1,46 @@
+import { useSourceConfigVisible } from '@/pages/_components/source-config';
+import { DownOutlined } from '@ant-design/icons';
+import { DropdownActions } from '@gpustack/core-ui';
+import { useIntl } from '@umijs/max';
+import { Button, Space } from 'antd';
+import React from 'react';
+import BackendSourceEntry from './backend-source-entry';
+
+export interface RightActionsProps {
+  actionItems: any[];
+  handleClickPrimary: (item: any) => void;
+  onSourceSaved: () => void;
+}
+
+/**
+ * Replaces FilterBar's default right side so the source drawer can sit beside
+ * the add button. Mirrors what FilterBar renders for `actionType="dropdown"`.
+ */
+const RightActions: React.FC<RightActionsProps> = ({
+  actionItems,
+  handleClickPrimary,
+  onSourceSaved
+}) => {
+  const intl = useIntl();
+  // Gated here rather than inside the entry: a `Space` item that renders
+  // nothing still takes its gap.
+  const showSourceEntry = useSourceConfigVisible();
+
+  return (
+    <Space size={16}>
+      {showSourceEntry && (
+        <BackendSourceEntry onSaved={onSourceSaved}></BackendSourceEntry>
+      )}
+      <DropdownActions
+        styles={{ root: { minWidth: '140px' } }}
+        menu={{ items: actionItems, onClick: handleClickPrimary }}
+      >
+        <Button icon={<DownOutlined />} type="primary" iconPlacement="end">
+          {intl.formatMessage({ id: 'backend.button.add' })}
+        </Button>
+      </DropdownActions>
+    </Space>
+  );
+};
+
+export default RightActions;

--- a/src/pages/backends/config/index.ts
+++ b/src/pages/backends/config/index.ts
@@ -317,3 +317,30 @@ version_configs:
     custom_framework: rocm
     env:
   `;
+
+// Schema hint seeded into the community backend source editor. Mirrors the
+// packaged community-inference-backends.yaml: a list of backend configs, each
+// keyed by backend_name with at least one version_configs entry carrying an
+// image_name. Comments only, so it cannot be saved unedited.
+export const backendSourceTemplate = `# A YAML list of community backend configs.
+#
+# Required per entry:
+#   backend_name     unique name of the backend
+#   version_configs  map of version name -> config, each with an image_name
+#
+# Example:
+#
+# - backend_name: Kokoro-FastAPI
+#   description: Inference backend serving the Kokoro TTS model.
+#   # icon must be an absolute URL, a '/'-rooted path, or a raster data: URI
+#   icon: https://example.com/icons/kokoro.png
+#   health_check_path: /health
+#   default_version: latest-gpu
+#   version_configs:
+#     latest-gpu:
+#       image_name: ghcr.io/remsky/kokoro-fastapi-gpu:latest
+#       custom_framework: cuda
+#     latest-cpu:
+#       image_name: ghcr.io/remsky/kokoro-fastapi-cpu:latest
+#       custom_framework: cpu
+`;

--- a/src/pages/backends/index.tsx
+++ b/src/pages/backends/index.tsx
@@ -24,6 +24,7 @@ import {
 import AddCommunityModal from './community/add-community-modal';
 import AddModal from './components/add-modal';
 import BackendCardList from './components/backend-list';
+import RightActions from './components/right-actions';
 import VersionInfoModal from './components/version-info-modal';
 import {
   backendSourceOptions,
@@ -41,7 +42,6 @@ const BackendList = () => {
 
   const {
     dataSource,
-    rowSelection,
     queryParams,
     modalRef,
     handleQueryChange,
@@ -249,21 +249,27 @@ const BackendList = () => {
         widths={{
           input: 230
         }}
-        actionItems={addActions}
-        actionType="dropdown"
         inputHolder={intl.formatMessage({ id: 'common.filter.name' })}
         selectHolder={intl.formatMessage({ id: 'backend.filter.source' })}
-        buttonText={intl.formatMessage({ id: 'backend.button.add' })}
-        handleClickPrimary={handleAddBackend}
         handleSearch={handleRefresh}
         handleSelectChange={handleFilterBySource}
         handleInputChange={handleNameChange}
-        rowSelection={rowSelection}
         showSelect={true}
         selectOptions={backendSourceOptions.map((item) => ({
           label: intl.formatMessage({ id: item.label }),
           value: item.value
         }))}
+        // Replaces the default right side wholesale, so the props that would
+        // have built it (`actionItems` / `actionType` / `buttonText` /
+        // `handleClickPrimary`, and `rowSelection`, which only drove its batch
+        // delete) have no effect and are not passed.
+        right={
+          <RightActions
+            actionItems={addActions}
+            handleClickPrimary={handleAddBackend}
+            onSourceSaved={handleSearch}
+          ></RightActions>
+        }
       ></FilterBar>
       <InfiniteScrollerProvider
         value={{

--- a/src/pages/llmodels/catalog.tsx
+++ b/src/pages/llmodels/catalog.tsx
@@ -11,19 +11,24 @@ import {
   useBodyScroll
 } from '@gpustack/core-ui';
 import { useIntl, useNavigate } from '@umijs/max';
-import { message } from 'antd';
+import { Button, Space, message } from 'antd';
 import { useAtom } from 'jotai';
 import _ from 'lodash';
 import React, { useCallback, useEffect, useState } from 'react';
 import PageBox from '../_components/page-box';
+import { useSourceConfigVisible } from '../_components/source-config';
 import { createModel, queryCatalogItemSpec, queryCatalogList } from './apis';
 import CatalogList from './components/catalog/catalog-list';
+import CatalogSourceEntry from './components/catalog/catalog-source-entry';
 import DelopyBuiltInModal from './components/deployment/deploy-builtin-modal';
 import { modelCategories, modelSourceMap } from './config';
 import { CatalogItem as CatalogItemType, FormData } from './config/types';
 
 const Catalog: React.FC = () => {
   const intl = useIntl();
+  // Gated here rather than inside the entry: a `Space` item that renders
+  // nothing still takes its gap.
+  const showSourceEntry = useSourceConfigVisible();
   const {
     dataSource,
     queryParams,
@@ -140,14 +145,28 @@ const Catalog: React.FC = () => {
         selectHolder={intl.formatMessage({ id: 'models.filter.category' })}
         marginBottom={22}
         marginTop={0}
-        buttonText={intl.formatMessage({ id: 'models.catalog.button.explore' })}
         handleSearch={handleSearch}
         handleSelectChange={handleCategoryChange}
-        handleClickPrimary={handleDeployFromOtherHubs}
         handleInputChange={handleNameChange}
         selectOptions={categoryOptions}
-        buttonIcon={<SearchOutlined />}
         widths={{ input: 230, select: 200 }}
+        // Replaces the default right side wholesale, so the props that would
+        // have built it (`buttonText` / `buttonIcon` / `handleClickPrimary`)
+        // have no effect and are not passed.
+        right={
+          <Space size={16}>
+            {showSourceEntry && (
+              <CatalogSourceEntry onSaved={handleSearch}></CatalogSourceEntry>
+            )}
+            <Button
+              icon={<SearchOutlined />}
+              type="primary"
+              onClick={handleDeployFromOtherHubs}
+            >
+              {intl.formatMessage({ id: 'models.catalog.button.explore' })}
+            </Button>
+          </Space>
+        }
       ></FilterBar>
       <InfiniteScrollerProvider
         value={{

--- a/src/pages/llmodels/components/catalog/catalog-item.tsx
+++ b/src/pages/llmodels/components/catalog/catalog-item.tsx
@@ -1,5 +1,6 @@
 import fallbackImg from '@/assets/images/img.png';
 import { categoryConfig } from '@/pages/_components/model-tag';
+import { isCustomSourceType } from '@/pages/_components/source-config/config';
 import { AutoTooltip, IconFont, ThemeTag } from '@gpustack/core-ui';
 import { useIntl } from '@umijs/max';
 import { Typography } from 'antd';
@@ -68,6 +69,16 @@ const CatalogItem: React.FC<CatalogItemProps> = (props) => {
             />
           </div>
           <AutoTooltip ghost>{data.name}</AutoTooltip>
+          {/* platform-owned entries (builtin / official) carry no badge */}
+          {isCustomSourceType(data.source_type) && (
+            <ThemeTag
+              color="purple"
+              opacity={0.7}
+              style={{ flex: 'none', marginInline: 'auto 0' }}
+            >
+              {intl.formatMessage({ id: 'common.source.tag.custom' })}
+            </ThemeTag>
+          )}
         </div>
       </div>
       <div className="item-footer">

--- a/src/pages/llmodels/components/catalog/catalog-source-entry.tsx
+++ b/src/pages/llmodels/components/catalog/catalog-source-entry.tsx
@@ -1,0 +1,27 @@
+import SourceConfigEntry from '@/pages/_components/source-config';
+import { querySourceProbe } from '@/pages/_components/source-config/probe';
+import type { SourceScopeConfig } from '@/pages/_components/source-config/types';
+import React from 'react';
+import { catalogSourceTemplate } from '../../config';
+
+// The catalog is the one kind that accepts an inline file, so its custom branch
+// offers Yaml File beside URL. A single kind, so the drawer shows its form
+// directly rather than in a panel.
+const catalogSourceScope: SourceScopeConfig = {
+  titleKey: 'models.catalog.source.title',
+  probe: querySourceProbe,
+  slots: [
+    {
+      kind: 'catalog',
+      allowFile: true,
+      officialDescriptionKey: 'models.catalog.source.official',
+      contentTemplate: catalogSourceTemplate
+    }
+  ]
+};
+
+const CatalogSourceEntry: React.FC<{ onSaved?: () => void }> = ({
+  onSaved
+}) => <SourceConfigEntry config={catalogSourceScope} onSaved={onSaved} />;
+
+export default CatalogSourceEntry;

--- a/src/pages/llmodels/config/index.ts
+++ b/src/pages/llmodels/config/index.ts
@@ -501,3 +501,37 @@ export enum DeployFormKeyMap {
   DEPLOYMENT = 'deployment',
   CATALOG = 'catalog'
 }
+
+// Schema hint seeded into the catalog source editor. Mirrors the packaged
+// model-catalog.yaml: a mapping with model_sets (and optionally draft_models),
+// each model set carrying at least one spec. Comments only, so it cannot be
+// saved unedited.
+export const catalogSourceTemplate = `# A YAML mapping with model_sets (and optionally draft_models).
+#
+# Example:
+#
+# model_sets:
+#   - name: Qwen3-0.6B
+#     description: Dense causal language model with a 128K context.
+#     home: https://qwenlm.github.io
+#     # icon must be an absolute URL, a '/'-rooted path, or a raster data: URI
+#     icon: https://example.com/icons/qwen.png
+#     size: 0.6
+#     categories:
+#       - llm
+#     capabilities:
+#       - context/128K
+#       - tools
+#     licenses:
+#       - apache-2.0
+#     release_date: "2025-04-19"
+#     specs:
+#       - mode: standard
+#         quantization: BF16
+#         source: huggingface
+#         huggingface_repo_id: Qwen/Qwen3-0.6B
+#         backend: vLLM
+#         backend_parameters:
+#           - --max-model-len=8192
+# draft_models: []
+`;

--- a/src/pages/llmodels/config/types.ts
+++ b/src/pages/llmodels/config/types.ts
@@ -267,6 +267,10 @@ export interface CatalogItem {
   activated_size: number;
   licenses: string[];
   release_date: string;
+  // Which source materialized this entry. Absent / builtin / official all mean
+  // platform-owned content, which carries no badge.
+  source_name?: string;
+  source_type?: string;
 }
 
 export interface CatalogSpec {
@@ -407,6 +411,10 @@ export interface BackendOption {
   enabled: boolean;
   common_parameters?: string[];
   parameter_format?: 'space' | 'equal' | null;
+  // Which managed source produced the entry — null for the packaged content and
+  // for anything a user added by hand, neither of which carries a badge.
+  source_name?: string;
+  source_type?: string;
   versions: {
     label: string;
     value: string;
@@ -448,6 +456,8 @@ export interface BackendItem {
   enabled: boolean;
   common_parameters?: string[];
   parameter_format?: 'space' | 'equal' | null;
+  source_name?: string;
+  source_type?: string;
   versions: {
     version: string;
     env?: Record<string, any>;

--- a/src/pages/llmodels/forms/backend.tsx
+++ b/src/pages/llmodels/forms/backend.tsx
@@ -1,6 +1,8 @@
+import { isCustomSourceType } from '@/pages/_components/source-config/config';
 import { CaretDownOutlined, InfoCircleOutlined } from '@ant-design/icons';
 import {
   Select as SealSelect,
+  ThemeTag,
   TooltipList,
   useAppUtils
 } from '@gpustack/core-ui';
@@ -173,8 +175,22 @@ const BackendFields: React.FC = () => {
     handleCloseTips();
   };
 
+  // A backend is imported as a whole, so the source stamp is only meaningful
+  // here: a custom (file / url) source produced it, rather than the packaged
+  // content or a hand-added backend.
   const optionRender = (option: any) => {
-    return option.data.title;
+    return (
+      // ThemeTag is display:flex, so it needs a flex row to sit beside the name
+      // instead of breaking onto a line of its own inside the option content.
+      <span className="flex-center gap-8">
+        {option.data.title}
+        {isCustomSourceType(option.data?.source_type) && (
+          <ThemeTag color="purple" opacity={0.7} style={{ flex: 'none' }}>
+            {intl.formatMessage({ id: 'common.source.tag.custom' })}
+          </ThemeTag>
+        )}
+      </span>
+    );
   };
 
   const labelRender = (option: any) => {

--- a/src/pages/llmodels/hooks/use-query-backends.ts
+++ b/src/pages/llmodels/hooks/use-query-backends.ts
@@ -65,7 +65,9 @@ export default function useQueryBackends() {
             'default_backend_param',
             'default_env',
             'common_parameters',
-            'parameter_format'
+            'parameter_format',
+            'source_name',
+            'source_type'
           ]),
           backend_source: item.backend_source || BackendSourceValueMap.CUSTOM,
           value: item.backend_name,


### PR DESCRIPTION
https://github.com/gpustack/gpustack/issues/5518

backend pr:
https://github.com/gpustack/gpustack/pull/6018

A drawer on the model catalog and inference backend pages configures each kind of content: the embedded copy GPUStack was packaged with, a URL that follows the official source or one of your own, or — for the catalog — an inline document. One row of cards picks between them, and Save writes the whole configuration in a single request.