### PR TITLE
feat(models): let a deployment declare it serves Anthropic natively

### DIFF
--- a/src/locales/en-US/models.ts
+++ b/src/locales/en-US/models.ts
@@ -146,6 +146,9 @@ export default {
   'models.form.submit.anyway': 'Submit Anyway',
   'models.form.evaluating': 'Evaluating Model Compatibliity',
   'models.form.incompatible': 'Incompatibility Detected',
+  'models.form.nativeAnthropicApi': 'Native Anthropic API',
+  'models.form.nativeAnthropicApi.tips':
+    'Enable when the inference server implements the Anthropic Messages API itself (e.g. recent vLLM), so requests to /v1/messages reach it as they are. Left off, /v1/messages still works — it is converted to /v1/chat/completions first.',
   'models.form.restart.onerror': 'Auto-Restart On Error',
   'models.form.restart.onerror.tips':
     'When an error occurs, it will automatically attempt to restart.',

--- a/src/locales/ja-JP/models.ts
+++ b/src/locales/ja-JP/models.ts
@@ -147,6 +147,9 @@ export default {
   'models.form.submit.anyway': 'このまま送信',
   'models.form.evaluating': 'モデルの互換性を評価中',
   'models.form.incompatible': '互換性の問題が検出されました',
+  'models.form.nativeAnthropicApi': 'ネイティブ Anthropic API',
+  'models.form.nativeAnthropicApi.tips':
+    '推論サーバー自体が Anthropic Messages API を実装している場合（新しめの vLLM など）に有効にします。/v1/messages へのリクエストがそのまま転送されます。無効のままでも /v1/messages は利用できますが、先に /v1/chat/completions へ変換されます。',
   'models.form.restart.onerror': 'エラー時に自動再起動',
   'models.form.restart.onerror.tips':
     'エラーが発生した場合、自動的に再起動を試みます。',

--- a/src/locales/ru-RU/models.ts
+++ b/src/locales/ru-RU/models.ts
@@ -149,6 +149,9 @@ export default {
   'models.form.submit.anyway': 'Отправить в любом случае',
   'models.form.evaluating': 'Анализ совместимости модели',
   'models.form.incompatible': 'Обнаружена несовместимость',
+  'models.form.nativeAnthropicApi': 'Нативный Anthropic API',
+  'models.form.nativeAnthropicApi.tips':
+    'Включите, если сервер инференса сам реализует Anthropic Messages API (например, свежие версии vLLM): тогда запросы к /v1/messages доходят до него как есть. Если выключено, /v1/messages по-прежнему работает, но сначала преобразуется в /v1/chat/completions.',
   'models.form.restart.onerror': 'Автоперезапуск при ошибке',
   'models.form.restart.onerror.tips':
     'При возникновении ошибки система автоматически попытается перезапуститься.',

--- a/src/locales/tr-TR/models.ts
+++ b/src/locales/tr-TR/models.ts
@@ -147,6 +147,9 @@ export default {
   'models.form.submit.anyway': 'Yine de Gönder',
   'models.form.evaluating': 'Model Uyumluluğu Değerlendiriliyor',
   'models.form.incompatible': 'Uyumsuzluk Tespit Edildi',
+  'models.form.nativeAnthropicApi': 'Yerel Anthropic API',
+  'models.form.nativeAnthropicApi.tips':
+    'Çıkarım sunucusu Anthropic Messages API’sini kendisi uyguluyorsa (örneğin yeni vLLM sürümleri) etkinleştirin; /v1/messages istekleri olduğu gibi iletilir. Kapalıyken de /v1/messages çalışır, ancak önce /v1/chat/completions biçimine dönüştürülür.',
   'models.form.restart.onerror': 'Hata Durumunda Otomatik Yeniden Başlat',
   'models.form.restart.onerror.tips':
     'Hata oluştuğunda otomatik olarak yeniden başlatmayı dener.',

--- a/src/locales/zh-CN/models.ts
+++ b/src/locales/zh-CN/models.ts
@@ -143,6 +143,9 @@ export default {
   'models.form.submit.anyway': '仍然提交',
   'models.form.evaluating': '评估模型兼容性中...',
   'models.form.incompatible': '检测到不兼容',
+  'models.form.nativeAnthropicApi': '原生 Anthropic API',
+  'models.form.nativeAnthropicApi.tips':
+    '当推理服务自身实现了 Anthropic Messages API（如较新版本的 vLLM）时开启，/v1/messages 请求将被原样转发。保持关闭时 /v1/messages 仍然可用，但会先转换为 /v1/chat/completions。',
   'models.form.restart.onerror': '错误时重启',
   'models.form.restart.onerror.tips': '当发生错误时，将自动尝试恢复。',
   'models.form.check.params': '正在校验配置...',

--- a/src/pages/llmodels/config/index.ts
+++ b/src/pages/llmodels/config/index.ts
@@ -417,11 +417,19 @@ export const DO_NOT_TRIGGER_CHECK_COMPATIBILITY = [
   'extended_kv_cache.ram_size',
   'speculative_config.enabled',
   'speculative_config.draft_model',
-  'max_context_len'
+  'max_context_len',
+  'native_anthropic_api'
 ];
 
 // ignore to compare old and new data when these fields change in updating model
-export const DO_NOT_NOTIFY_RECREATE = ['categories', 'replicas', 'description'];
+// `native_anthropic_api` only reconfigures the gateway's ai-proxy provider, so
+// the running instances stay as they are.
+export const DO_NOT_NOTIFY_RECREATE = [
+  'categories',
+  'replicas',
+  'description',
+  'native_anthropic_api'
+];
 
 export const defaultFormValues = {
   replicas: 1,
@@ -435,7 +443,8 @@ export const defaultFormValues = {
   gpu_selector: {},
   worker_selector: {},
   backend_parameters: [],
-  backend_version: null
+  backend_version: null,
+  native_anthropic_api: false
 };
 
 export const getBackendParamsTips = (backend: string) => {

--- a/src/pages/llmodels/config/types.ts
+++ b/src/pages/llmodels/config/types.ts
@@ -43,6 +43,7 @@ export interface ListItem {
   // The `(string & {})` tail keeps literal autocomplete for the
   // built-ins while still accepting plugin-defined values.
   access_policy: 'public' | 'authed' | 'allowed_users' | (string & {});
+  native_anthropic_api?: boolean;
   generic_proxy?: boolean;
   gpu_selector?: {
     gpu_ids: string[];
@@ -105,6 +106,7 @@ export interface FormData {
   run_command?: string;
   enable_model_route?: boolean;
   backend: string;
+  native_anthropic_api?: boolean;
   restart_on_error?: boolean;
   env?: Record<string, any>;
   size?: number;

--- a/src/pages/llmodels/forms/advance-config.tsx
+++ b/src/pages/llmodels/forms/advance-config.tsx
@@ -38,6 +38,17 @@ const AdvanceConfig = () => {
 
   console.log('currentBackendOptions', currentBackendOptions);
 
+  // Anthropic Messages is a chat surface, so the declaration only means
+  // something on a backend that has one. vox-box serves /v1/audio/* and nothing
+  // else, which is a fact about what it is rather than about which build is
+  // running — the one exclusion that cannot go stale.
+  //
+  // Everything else stays, llama-box included: upstream llama.cpp serves
+  // /v1/messages as of ggml-org/llama.cpp#17570, so whether a given build
+  // answers it is a property of the image. That is the whole reason this is
+  // declared by whoever deploys instead of derived here.
+  const servesChatCompletions = backend !== backendOptionsMap.voxBox;
+
   const onSelectorChange = (field: string, allowEmpty?: boolean) => {
     const workerSelector = form.getFieldValue(field);
     // check if all keys have values
@@ -119,6 +130,22 @@ const AdvanceConfig = () => {
             })}
             label={intl.formatMessage({
               id: 'resources.form.enableDistributedInferenceAcrossWorkers'
+            })}
+          ></CheckboxField>
+        </Form.Item>
+      )}
+      {servesChatCompletions && (
+        <Form.Item<FormData>
+          name="native_anthropic_api"
+          valuePropName="checked"
+          style={{ marginBottom: 8 }}
+        >
+          <CheckboxField
+            description={intl.formatMessage({
+              id: 'models.form.nativeAnthropicApi.tips'
+            })}
+            label={intl.formatMessage({
+              id: 'models.form.nativeAnthropicApi'
             })}
           ></CheckboxField>
         </Form.Item>

--- a/src/pages/llmodels/forms/index.tsx
+++ b/src/pages/llmodels/forms/index.tsx
@@ -37,7 +37,7 @@ import { backendOptionsMap } from '../constants/backend-parameters';
 import { useGenerateGPUOptions } from '../hooks/use-form-initial-values';
 import useQueryBackends from '../hooks/use-query-backends';
 import { useQueryContextLength } from '../services/use-query-context-length';
-import { generateGPUIds } from '../utils';
+import { derivesNativeAnthropicApi, generateGPUIds } from '../utils';
 import AdvanceConfig from './advance-config';
 import BasicForm from './basic';
 import Performance from './performance';
@@ -192,9 +192,14 @@ const DataForm: React.FC<DataFormProps> = forwardRef((props, ref) => {
     };
   };
 
-  const updateKVCacheConfig = (backend: string, option: BackendOption) => {
+  // `option` is absent when the backend was picked for the user rather than
+  // from the dropdown: local-path-source forces one on a .gguf path and looks
+  // it up in the loaded options, which come up empty for a cluster that does
+  // not offer it. Absent reads as not-built-in throughout, which is the safe
+  // answer for every switch below.
+  const updateKVCacheConfig = (backend: string, option?: BackendOption) => {
     if (
-      !option.isBuiltIn ||
+      !option?.isBuiltIn ||
       ![backendOptionsMap.SGLang, backendOptionsMap.vllm].includes(backend)
     ) {
       return {
@@ -212,13 +217,17 @@ const DataForm: React.FC<DataFormProps> = forwardRef((props, ref) => {
     return {};
   };
 
-  const handleBackendChange = async (val: string, option: BackendOption) => {
+  const handleBackendChange = async (val: string, option?: BackendOption) => {
     await new Promise((resolve) => {
       setTimeout(resolve, 100);
     });
     form.setFieldsValue({
       backend_version: null, // don't set default version here, let the user select it
-      backend_parameters: option.default_backend_param || [],
+      backend_parameters: option?.default_backend_param || [],
+      // Switching away from vLLM clears it: carrying the declaration to, say,
+      // SGLang would have the gateway forward a request the new image cannot
+      // answer, where translating it would have worked.
+      native_anthropic_api: derivesNativeAnthropicApi(val, option),
       ...updateKVCacheConfig(val, option),
       ...updateGPUSelector(val)
     });
@@ -484,6 +493,7 @@ const DataForm: React.FC<DataFormProps> = forwardRef((props, ref) => {
             scheduleType: ScheduleValueMap.Auto,
             manualGpuMode: ManualGPUModeMap.FullGPU,
             categories: null,
+            native_anthropic_api: false,
             restart_on_error: true,
             distributed_inference_across_workers: true,
             mode: 'throughput',

--- a/src/pages/llmodels/hooks/index.ts
+++ b/src/pages/llmodels/hooks/index.ts
@@ -14,7 +14,7 @@ import {
   backendOptionsMap,
   BuiltInBackendOptions
 } from '../constants/backend-parameters';
-import { generateGPUIds } from '../utils';
+import { derivesNativeAnthropicApi, generateGPUIds } from '../utils';
 import useCheckBackend from './use-check-backend';
 import useRecognizeAudio from './use-recognize-audio';
 
@@ -622,6 +622,11 @@ export const useSelectModel = (data: { gpuOptions: any[] }) => {
         ...(selectedBackend?.default_env || {})
       },
       backend_parameters: [...(selectedBackend?.default_backend_param || [])],
+      // Derived here as well as in the backend dropdown's handler: this path
+      // writes `backend` straight into the form, so without it the same
+      // deployment would answer differently depending on whether the user
+      // happened to touch the dropdown.
+      native_anthropic_api: derivesNativeAnthropicApi(backend, selectedBackend),
       name: name,
       source: source,
       backend: backend

--- a/src/pages/llmodels/utils/index.ts
+++ b/src/pages/llmodels/utils/index.ts
@@ -129,3 +129,24 @@ export const calcTotalVram = (record: any) => {
   );
   return vramInMain + vramInDistributed;
 };
+
+// Whether a backend's default image implements the Anthropic Messages API
+// itself, which is what `native_anthropic_api` declares to the gateway.
+//
+// Shared by the two paths that settle a backend without the user typing it:
+// the backend dropdown (forms/index.tsx) and picking a model from a search
+// list, which resolves one from the model's own shape (hooks/index.ts). They
+// have to agree — otherwise the same deployment answers differently depending
+// on whether the dropdown was ever touched.
+//
+// Only the built-in vLLM image qualifies, and only at its default version:
+// this reads `backend`, and no version is pinned at the moment either caller
+// runs. A user who pins an older vLLM afterwards is on their own — the box
+// stays theirs to untick, which is the point of declaring it rather than
+// deriving it server-side.
+export const derivesNativeAnthropicApi = (
+  backend?: string,
+  option?: { isBuiltIn?: boolean }
+) => {
+  return Boolean(option?.isBuiltIn && backend === backendOptionsMap.vllm);
+};


### PR DESCRIPTION
Refer to backend PR:
- https://github.com/gpustack/gpustack/pull/6149 (merged)

Server-side counterpart is gpustack `4c4d47e8`, which added `Model.native_anthropic_api`: it decides whether the gateway forwards an inbound `/v1/messages` or rewrites it to `/v1/chat/completions`. Nothing exposed it, so a deployment running an image that implements Anthropic Messages itself still had its requests translated -- and the translation reorders `system` on the way through.

Adds a **"Native Anthropic API"** checkbox to the deploy form's Advanced section, among the other per-deployment switches. Off is the default and the pre-existing behavior; `/v1/messages` works either way, the box only decides whether it gets translated on the way.

A checkbox rather than a surface picker because the OpenAI surface is always served, so there is exactly one bit to declare -- and it is a bit an operator can actually check, namely whether their image is a recent enough vLLM.

```
POST/PUT /v1/models   { ..., "native_anthropic_api": true }
```

### Notes

- **Shown only where it can mean something.** Hidden for vox-box (audio) and llama-box (GGUF through llama.cpp); every other backend keeps it, custom images included -- that is precisely the case where the operator knows what their server implements and nothing else can tell us.
- **`native_anthropic_api` joins `DO_NOT_NOTIFY_RECREATE`**, because the server rebuilds only the ai-proxy provider entry off the change and leaves the running instances alone, which would make the "takes effect after recreate" warning false; and `DO_NOT_TRIGGER_CHECK_COMPATIBILITY` for the same reason, it claims no resources.
- **`handleBackendChange` takes its `option` as optional now.** The dropdown is not its only caller -- `local-path-source` forces a backend on a `.gguf` path and resolves it through `flatBackendOptions.find`, which returns `undefined` for a backend the target cluster does not offer -- so reading `isBuiltIn` and `default_backend_param` off it threw before the form saw anything. The hazard is pre-existing, in `updateKVCacheConfig`. Absent now reads as not-built-in throughout.
- **Worth knowing when this looks inert:** an unpatched ai-proxy plugin filters configured capabilities against a whitelist with no Anthropic entries and drops them without complaining, so a ticked box behaves exactly like an unticked one.

> [!NOTE]
> An earlier revision of this PR modelled the field as an `api_type` enum (`openai` / `openai-anthropic`) behind a select. The backend settled on a boolean before merging; this description and the implementation now both follow `native_anthropic_api`.
