### PR TITLE
fix: read the renamed default_metrics off cache providers

### DIFF
--- a/src/pages/kv-cache/config/types.ts
+++ b/src/pages/kv-cache/config/types.ts
@@ -106,10 +106,11 @@ export interface CacheProviderItem {
   // structured configuration fields shown on the managed form, wired
   // into the runtime config via their {{name}} template placeholders
   managed_fields?: CacheProviderField[];
-  // where the service's Prometheus exposition is scraped; default_port
-  // seeds the registration form's metrics-port field for external
-  // providers
-  metrics?: {
+  // the all-version default of where the service's Prometheus
+  // exposition is scraped (a version may override it server-side);
+  // default_port seeds the registration form's metrics-port field for
+  // external providers
+  default_metrics?: {
     path?: string;
     default_port?: number;
     [key: string]: any;

--- a/src/pages/kv-cache/forms/index.tsx
+++ b/src/pages/kv-cache/forms/index.tsx
@@ -504,7 +504,7 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
       // master's 9003) seeds the field; the user overrides as needed
       form.setFieldValue(
         ['endpoint', 'metrics_port'],
-        provider?.metrics?.default_port
+        provider?.default_metrics?.default_port
       );
     }
   };


### PR DESCRIPTION
The catalog API serializes the provider model as-is, and the backend renamed the provider-level metrics block to default_metrics (a version may override it server-side). The registration form read the old name, so Mooncake's metrics-port field silently stopped seeding its 9003 default.