### PR TITLE
feat(clusters): let a Kubernetes cluster override the server URL

### DIFF
--- a/src/locales/en-US/clusters.ts
+++ b/src/locales/en-US/clusters.ts
@@ -117,8 +117,8 @@ export default {
     '{count} new workers have been added to the cluster.',
   'clusters.create.serverUrl': 'GPUStack Server URL',
   'clusters.create.workerConfig': 'Worker Configuration',
-  'clusters.edit.k8sOptions.changed.tip':
-    'You have changed the Kubernetes options. Re-run the registration command on the target cluster for the changes to take effect.',
+  'clusters.edit.registration.changed.tip':
+    'You have changed settings that are applied when a worker registers. Re-run the registration command on the target cluster for the changes to take effect.',
   'clusters.addworker.containerName': 'Worker Container Name',
   'clusters.addworker.containerName.tips':
     'Specify a name for the worker container.',
@@ -128,7 +128,7 @@ export default {
   'clusters.table.ip.internal': 'Internal',
   'clusters.table.ip.external': 'External',
   'clusters.form.serverUrl.tips':
-    'Specify an externally accessible GPUStack service URL if the worker cannot access GPUStack Server directly.',
+    'Specify an externally accessible GPUStack service URL if the worker cannot access GPUStack Server directly. For example: {example}',
   'clusters.form.setDefault': 'Set as Default',
   'clusters.form.setDefault.tips': 'Default for deployment.',
   'clusters.addworker.noClusters': 'No available Docker clusters found',

--- a/src/locales/ja-JP/clusters.ts
+++ b/src/locales/ja-JP/clusters.ts
@@ -117,8 +117,8 @@ export default {
     '{count} new workers have been added to the cluster.',
   'clusters.create.serverUrl': 'GPUStack Server URL',
   'clusters.create.workerConfig': 'Worker Configuration',
-  'clusters.edit.k8sOptions.changed.tip':
-    'Kubernetes オプションを変更しました。変更を有効にするには、対象クラスターで登録コマンドを再実行してください。',
+  'clusters.edit.registration.changed.tip':
+    'ワーカーの登録時に適用される設定を変更しました。変更を有効にするには、対象クラスターで登録コマンドを再実行してください。',
   'clusters.addworker.containerName': 'Worker Container Name',
   'clusters.addworker.containerName.tips':
     'Specify a name for the worker container.',
@@ -128,7 +128,7 @@ export default {
   'clusters.table.ip.internal': 'Internal',
   'clusters.table.ip.external': 'External',
   'clusters.form.serverUrl.tips':
-    'Specify an externally accessible GPUStack service URL if the worker cannot access GPUStack Server directly.',
+    'Specify an externally accessible GPUStack service URL if the worker cannot access GPUStack Server directly. For example: {example}',
   'clusters.form.setDefault': 'Set as Default',
   'clusters.form.setDefault.tips': 'Default for deployment.',
   'clusters.addworker.noClusters': 'No available Docker clusters found',

--- a/src/locales/ru-RU/clusters.ts
+++ b/src/locales/ru-RU/clusters.ts
@@ -115,10 +115,10 @@ export default {
     '{count} новый воркер был добавлен в кластер.',
   'clusters.addworker.message.success_multiple':
     '{count} новых воркеров были добавлены в кластер.',
-  'clusters.create.serverUrl': 'URL сервера GPUStack',
+  'clusters.create.serverUrl': 'GPUStack Server URL',
   'clusters.create.workerConfig': 'Конфигурация воркера',
-  'clusters.edit.k8sOptions.changed.tip':
-    'Вы изменили параметры Kubernetes. Чтобы изменения вступили в силу, повторно выполните команду регистрации в целевом кластере.',
+  'clusters.edit.registration.changed.tip':
+    'Вы изменили параметры, которые применяются при регистрации воркера. Чтобы изменения вступили в силу, повторно выполните команду регистрации в целевом кластере.',
   'clusters.addworker.containerName': 'Имя контейнера воркера',
   'clusters.addworker.containerName.tips':
     'Укажите имя для контейнера воркера.',
@@ -128,7 +128,7 @@ export default {
   'clusters.table.ip.internal': 'Внутренний',
   'clusters.table.ip.external': 'Внешний',
   'clusters.form.serverUrl.tips':
-    'Если рабочий узел не может напрямую получить доступ к GPUStack Server, укажите внешний URL службы GPUStack Server.',
+    'Если рабочий узел не может напрямую получить доступ к GPUStack Server, укажите внешний URL службы GPUStack Server. Например: {example}',
   'clusters.form.setDefault': 'Установить по умолчанию',
   'clusters.form.setDefault.tips':
     'Использовать по умолчанию для развертывания.',

--- a/src/locales/tr-TR/clusters.ts
+++ b/src/locales/tr-TR/clusters.ts
@@ -115,10 +115,10 @@ export default {
     '{count} yeni işçi düğüm kümeye eklendi.',
   'clusters.addworker.message.success_multiple':
     '{count} yeni işçi düğüm kümeye eklendi.',
-  'clusters.create.serverUrl': "GPUStack Sunucu URL'si",
+  'clusters.create.serverUrl': 'GPUStack Server URL',
   'clusters.create.workerConfig': 'İşçi Düğüm Yapılandırması',
-  'clusters.edit.k8sOptions.changed.tip':
-    'Kubernetes seçeneklerini değiştirdiniz. Değişikliklerin etkili olması için kayıt komutunu hedef kümede yeniden çalıştırın.',
+  'clusters.edit.registration.changed.tip':
+    'Bir işçi düğüm kaydolurken uygulanan ayarları değiştirdiniz. Değişikliklerin etkili olması için kayıt komutunu hedef kümede yeniden çalıştırın.',
   'clusters.addworker.containerName': 'İşçi Düğüm Konteyner Adı',
   'clusters.addworker.containerName.tips':
     'İşçi düğüm konteyneri için bir ad belirtin.',
@@ -128,7 +128,7 @@ export default {
   'clusters.table.ip.internal': 'Dahili',
   'clusters.table.ip.external': 'Harici',
   'clusters.form.serverUrl.tips':
-    "İşçi düğüm GPUStack Sunucusuna doğrudan erişemiyorsa, harici olarak erişilebilir bir GPUStack hizmet URL'si belirtin.",
+    "İşçi düğüm GPUStack Sunucusuna doğrudan erişemiyorsa, harici olarak erişilebilir bir GPUStack hizmet URL'si belirtin. Örneğin: {example}",
   'clusters.form.setDefault': 'Varsayılan Olarak Ayarla',
   'clusters.form.setDefault.tips': 'Dağıtım için varsayılan.',
   'clusters.addworker.noClusters': 'Kullanılabilir Docker kümesi bulunamadı',

--- a/src/locales/zh-CN/clusters.ts
+++ b/src/locales/zh-CN/clusters.ts
@@ -113,10 +113,10 @@ export default {
     '已将 {count} 个新节点添加到集群中。',
   'clusters.addworker.message.success_multiple':
     '已将 {count} 个新节点添加到集群中。',
-  'clusters.create.serverUrl': 'GPUStack Server 节点地址',
+  'clusters.create.serverUrl': 'GPUStack Server URL',
   'clusters.create.workerConfig': '节点配置',
-  'clusters.edit.k8sOptions.changed.tip':
-    '您已修改 Kubernetes 选项，需要在目标集群上重新运行注册命令才会生效。',
+  'clusters.edit.registration.changed.tip':
+    '您已修改注册节点时生效的配置，需要在目标集群上重新运行注册命令才会生效。',
   'clusters.addworker.containerName': '节点容器名称',
   'clusters.addworker.containerName.tips': '为节点容器指定一个名称。',
   'clusters.addworker.dataVolume': 'GPUStack 数据卷',
@@ -124,7 +124,7 @@ export default {
   'clusters.table.ip.internal': '内',
   'clusters.table.ip.external': '外',
   'clusters.form.serverUrl.tips':
-    '如果节点无法直接访问 GPUStack Server，则指定一个可访问的外部 GPUStack Server 地址。',
+    '如果节点无法直接访问 GPUStack Server，则指定一个可访问的外部 GPUStack Server 地址。例如：{example}',
   'clusters.form.setDefault': '设为默认',
   'clusters.form.setDefault.tips': '部署时的默认集群。',
   'clusters.addworker.noClusters': '无可用的 Docker 集群',

--- a/src/pages/cluster-management/components/add-cluster.tsx
+++ b/src/pages/cluster-management/components/add-cluster.tsx
@@ -45,9 +45,10 @@ const AddCluster: React.FC<AddModalProps> = ({
   const intl = useIntl();
   const form = useRef<any>(null);
   const { loading, guard, run, release } = useSubmitLock();
-  // Whether the user has changed any k8s_options field. Lifted from ClusterForm
-  // so the "re-run registration" notice can sit in the drawer footer, above the
-  // Save/Cancel buttons (mirrors the model edit interaction).
+  // Whether the user has changed any field that is only applied while a worker
+  // registers. Lifted from ClusterForm so the "re-run registration" notice can
+  // sit in the drawer footer, above the Save/Cancel buttons (mirrors the model
+  // edit interaction).
   const [k8sOptionsChanged, setK8sOptionsChanged] = useState<boolean>(false);
 
   const handleSubmit = () => {
@@ -85,7 +86,7 @@ const AddCluster: React.FC<AddModalProps> = ({
                 style={{ margin: '8px 24px 0' }}
                 icon={<ExclamationCircleFilled />}
                 message={intl.formatMessage({
-                  id: 'clusters.edit.k8sOptions.changed.tip'
+                  id: 'clusters.edit.registration.changed.tip'
                 })}
               ></AlertBlockInfo>
             )}

--- a/src/pages/cluster-management/components/cloud-provider-form.tsx
+++ b/src/pages/cluster-management/components/cloud-provider-form.tsx
@@ -1,11 +1,7 @@
 import { fromClusterCreationAtom } from '@/atoms/clusters';
 import { PageAction } from '@/config';
 import { PageActionType } from '@/config/types';
-import {
-  Input as CInput,
-  Select as SealSelect,
-  useAppUtils
-} from '@gpustack/core-ui';
+import { Select as SealSelect, useAppUtils } from '@gpustack/core-ui';
 import { Link, useIntl } from '@umijs/max';
 import { Form } from 'antd';
 import { useAtom } from 'jotai';
@@ -17,6 +13,7 @@ import { providerHasRegions } from '../config/cloud-providers';
 import { useStepsContext } from '../config/steps-context';
 import { ClusterFormData as FormData } from '../config/types';
 import { useProviderRegions } from '../hooks/use-provider-regions';
+import ServerUrlField from './server-url-field';
 
 const OptionItem = styled.div`
   display: flex;
@@ -204,24 +201,7 @@ const CloudProvider: React.FC<CloudProviderProps> = (props) => {
           ></SealSelect>
         </Form.Item>
       )}
-      <Form.Item<FormData>
-        name="server_url"
-        rules={[
-          {
-            required: true,
-            message: getRuleMessage('input', 'clusters.create.serverUrl')
-          }
-        ]}
-      >
-        <CInput.Input
-          description={intl.formatMessage({
-            id: 'clusters.form.serverUrl.tips'
-          })}
-          label={intl.formatMessage({ id: 'clusters.create.serverUrl' })}
-          required={true}
-          trim={true}
-        ></CInput.Input>
-      </Form.Item>
+      <ServerUrlField provider={provider} required />
     </>
   );
 };

--- a/src/pages/cluster-management/components/cluster-form.tsx
+++ b/src/pages/cluster-management/components/cluster-form.tsx
@@ -30,6 +30,7 @@ import K8sAdvancedOptions, {
   ClusterTypeSelector,
   K8sOptionsChangeWatcher
 } from './k8s-pod-spec';
+import ServerUrlField from './server-url-field';
 
 type AddModalProps = {
   action: PageActionType;
@@ -331,6 +332,12 @@ const ClusterForm: React.FC<AddModalProps> = forwardRef(
                 forceRender: true,
                 children: (
                   <>
+                    {/* Docker and Kubernetes register their own workers, so the
+                        server URL is an optional override here. Cloud providers
+                        get a required copy in the basic form instead. */}
+                    {!isCloudProvider(provider) && (
+                      <ServerUrlField provider={provider} />
+                    )}
                     {provider === ProviderValueMap.Kubernetes && (
                       <K8sAdvancedOptions
                         key={currentData?.id ?? 'new'}

--- a/src/pages/cluster-management/components/k8s-pod-spec.tsx
+++ b/src/pages/cluster-management/components/k8s-pod-spec.tsx
@@ -353,8 +353,9 @@ const nullishCustomizer = (val1: any, val2: any) => {
 };
 
 // Headless watcher: in EDIT mode it reports (via onChange) whether the user has
-// changed any k8s_options field or the top-level system_default_container_registry
-// from the cluster's saved values. It renders nothing — the notice itself is shown
+// changed any k8s_options field or one of the top-level fields the registration
+// command bakes in (system_default_container_registry, server_url) from the
+// cluster's saved values. It renders nothing — the notice itself is shown
 // in the form footer, above Save/Cancel (see cluster-create.tsx), mirroring the
 // model edit interaction. Must be mounted inside the cluster <Form> so the watch
 // reads the form store.
@@ -370,6 +371,7 @@ export const K8sOptionsChangeWatcher: React.FC<{
   const containerRegistry = Form.useWatch('system_default_container_registry', {
     preserve: true
   });
+  const serverUrl = Form.useWatch('server_url', { preserve: true });
 
   // currentData?.k8s_options is static for the form's lifetime — memoize the
   // cleaned version to avoid redundant deep-clone on every render
@@ -389,9 +391,17 @@ export const K8sOptionsChangeWatcher: React.FC<{
     containerRegistry,
     nullishCustomizer
   );
+  // The registration command prints `--server-url` from this value, so a change
+  // only reaches the workers once the command is re-run.
+  const serverUrlChanged = !_.isEqualWith(
+    currentData?.server_url,
+    serverUrl,
+    nullishCustomizer
+  );
 
   const changed =
-    action === PageAction.EDIT && (k8sOptionsChanged || registryChanged);
+    action === PageAction.EDIT &&
+    (k8sOptionsChanged || registryChanged || serverUrlChanged);
 
   useEffect(() => {
     onChange(changed);

--- a/src/pages/cluster-management/components/server-url-field.tsx
+++ b/src/pages/cluster-management/components/server-url-field.tsx
@@ -1,0 +1,64 @@
+import { systemConfigAtom } from '@/atoms/system';
+import { Input as CInput, useAppUtils } from '@gpustack/core-ui';
+import { useIntl } from '@umijs/max';
+import { Form } from 'antd';
+import { useAtomValue } from 'jotai';
+import React from 'react';
+import { getServerUrlExample, ProviderType } from '../config';
+import { ClusterFormData as FormData } from '../config/types';
+
+/**
+ * The GPUStack Server URL a worker registers against. A top-level cluster
+ * field — the backend hands it back from the cluster-token endpoint and the
+ * registration command bakes it into the `--server-url` it prints, so it is
+ * consumed during registration and cannot be changed later from the node
+ * config YAML (see gpustack/gpustack#5868).
+ *
+ * Two call sites, split by whether there is a registration step to fall back
+ * on. Docker and Kubernetes register their own workers, so the field is an
+ * optional override in the "Advanced" collapse: left empty, the cluster keeps
+ * following the platform's external URL, which the placeholder shows so the
+ * field reads as an override rather than a blank required value. Cloud
+ * providers provision workers themselves and have nothing to fall back on, so
+ * `components/cloud-provider-form` renders it `required` in the basic form.
+ *
+ * The tip's example comes from the provider (`getServerUrlExample`) — a
+ * Kubernetes Service DNS name reads nothing like the `ip:port` a Docker or
+ * cloud worker dials.
+ */
+const ServerUrlField: React.FC<{
+  provider: ProviderType;
+  required?: boolean;
+}> = ({ provider, required = false }) => {
+  const intl = useIntl();
+  const { getRuleMessage } = useAppUtils();
+  const systemConfig = useAtomValue(systemConfigAtom);
+
+  return (
+    <Form.Item<FormData>
+      name="server_url"
+      normalize={(value) => value?.trim?.() || null}
+      rules={[
+        {
+          required,
+          message: getRuleMessage('input', 'clusters.create.serverUrl')
+        }
+      ]}
+    >
+      <CInput.Input
+        label={intl.formatMessage({ id: 'clusters.create.serverUrl' })}
+        description={intl.formatMessage(
+          { id: 'clusters.form.serverUrl.tips' },
+          { example: getServerUrlExample(provider) }
+        )}
+        required={required}
+        placeholder={
+          systemConfig?.server_external_url || window.location.origin
+        }
+        trim={true}
+      ></CInput.Input>
+    </Form.Item>
+  );
+};
+
+export default ServerUrlField;

--- a/src/pages/cluster-management/config/index.ts
+++ b/src/pages/cluster-management/config/index.ts
@@ -126,6 +126,18 @@ export const CloudProviderList = [
 export const isCloudProvider = (provider?: ProviderType | string | null) =>
   !!provider && CloudProviderList.includes(provider as string);
 
+/**
+ * Example shown in the "GPUStack Server URL" field's tip, per provider. A
+ * Kubernetes worker reaches the server through an in-cluster Service, so its
+ * example is a Service DNS name; every other provider's workers are plain
+ * hosts on the network — a Docker daemon or a cloud instance — and dial an
+ * `ip:port` instead.
+ */
+export const getServerUrlExample = (provider?: ProviderType | string | null) =>
+  provider === ProviderValueMap.Kubernetes
+    ? 'http://gpustack-server-cluster-ip.gpustack-system.svc:30080'
+    : 'http://192.168.1.100:80';
+
 export const generateK8sRegisterCommand = (params: {
   // Either a single GPU driver key (legacy single-select) or an array of
   // keys (multi-vendor mode). Both feed into a list of runtimes for the

--- a/src/pages/cluster-management/config/types.ts
+++ b/src/pages/cluster-management/config/types.ts
@@ -126,6 +126,9 @@ export interface ClusterListItem {
   // a top-level column on the backend (image resolution / registration token
   // read it directly). Falls back to the server default when unset.
   system_default_container_registry?: string | null;
+  // Externally reachable GPUStack Server URL the workers register against.
+  // Unset means the platform's `server_external_url` is used instead.
+  server_url?: string | null;
   provider: ProviderType;
   credential_id: number;
   created_at: string;
@@ -153,7 +156,9 @@ export interface ClusterFormData {
   credential_id: number;
   zone: string;
   region: string;
-  server_url?: string;
+  // Empty means "follow the platform's external URL" — the field normalizes a
+  // cleared input to null so an edit can drop a previously set override.
+  server_url?: string | null;
   worker_config?: Record<string, any>;
   system_default_container_registry?: string | null;
   worker_pools?: NodePoolFormData[];


### PR DESCRIPTION
Refer to issues:
- https://github.com/gpustack/gpustack/issues/5868

Setting `server_url` in the node config YAML has no effect: the value is consumed during worker registration, long before the YAML is read. The only way to point workers at a different server is a per-cluster field, and that input had been hidden for Kubernetes.

Bring it back inside the "Advanced" collapse, above the other Kubernetes options. It is optional here rather than required as it is for cloud providers, which provision workers themselves and have no registration step to fall back on: cleared, it normalizes to null and the cluster keeps following the platform's `server_external_url`, shown as the placeholder so the field reads as an override.

Editing it also raises the "re-run the registration command" notice, since the command bakes the value into the `--server-url` it prints — the same reason `k8s_options` and the container registry already trigger it.
