### PR TITLE
fix: filter the storage picker by the label it shows

### DIFF
--- a/src/pages/gpu-service/instances/forms/storage-volume.tsx
+++ b/src/pages/gpu-service/instances/forms/storage-volume.tsx
@@ -200,6 +200,10 @@ const StorageVolume = ({
             <Select
               disabled={disabled}
               showSearch
+              // Without this the search filters on `value` (the storage's
+              // `name`) while the option renders `displayName || name`, so
+              // typing the label shown in the dropdown matches nothing.
+              optionFilterProp="label"
               label={intl.formatMessage({
                 id: 'gpuservice.form.storage.select'
               })}


### PR DESCRIPTION
Refer to issues:
- https://github.com/gpustack/gpustack/issues/6104

Backend counterpart: https://github.com/gpustack/gpustack/pull/6156

The storage dropdown in the GPU instance form renders `${displayName || name} / ${capacity}` for each option, but its search filtered on `value`, which is the storage's `name`. With `optionFilterProp` unset and flat `options`, rc-select falls through to `includes(option[fieldValue], search)` — verified against the installed `@rc-component/select@1.6.15`:

```js
if (optionFilterProp && optionFilterProp.length) { ... }   // unset -> [], skipped
if (option[fieldOptions]) { ... }                          // OptionGroup only
return includes(option[fieldValue], upperSearch);          // flat options -> filters by value
```

So typing the label the dropdown had just shown matched nothing. For a storage whose display name is set, the name is an opaque identifier the user never sees, which makes the picker's search effectively unusable — the client-side twin of the list-search bug fixed server-side in gpustack#6156.

The two Selects in the instance-type form already pass `optionFilterProp="label"`; this one had been missed.

Not changed here: 31 other `showSearch` selects across the app also leave the filter prop unset. Most are harmless — the default is correct wherever the label and the value agree — but the ones whose label differs from their value have the same defect, and they deserve their own sweep rather than being folded into a GPU Service fix.
