### PR TITLE
fix(i18n): translate the instance type name filter placeholder

### DIFF
--- a/src/locales/ja-JP/gpuservice.ts
+++ b/src/locales/ja-JP/gpuservice.ts
@@ -171,7 +171,7 @@ export default {
   'gpuservice.instanceType.localStorage': 'Storage',
   'gpuservice.instanceType.localStorage.tip': 'Maximum available disk',
   'gpuservice.instanceType.notSliceable': 'Not Sliceable',
-  'gpuservice.instanceType.filter.name': 'Search by name',
+  'gpuservice.instanceType.filter.name': '名前で検索',
   'gpuservice.instanceType.clusterUnavailable':
     'クラスターが応答しませんでした。準備完了の Worker がない可能性があります。クラスターを確認して再試行してください。',
   'gpuservice.instance.disk': 'ディスク',

--- a/src/locales/ru-RU/gpuservice.ts
+++ b/src/locales/ru-RU/gpuservice.ts
@@ -169,7 +169,7 @@ export default {
   'gpuservice.instanceType.localStorage': 'Storage',
   'gpuservice.instanceType.localStorage.tip': 'Maximum available disk',
   'gpuservice.instanceType.notSliceable': 'Not Sliceable',
-  'gpuservice.instanceType.filter.name': 'Search by name',
+  'gpuservice.instanceType.filter.name': 'Поиск по имени',
   'gpuservice.instanceType.clusterUnavailable':
     'Кластер не ответил, скорее всего потому, что в нём нет готового рабочего узла. Проверьте кластер и повторите попытку.',
   'gpuservice.instance.disk': 'Диск',

--- a/src/locales/tr-TR/gpuservice.ts
+++ b/src/locales/tr-TR/gpuservice.ts
@@ -166,7 +166,7 @@ export default {
   'gpuservice.instanceType.localStorage': 'Storage',
   'gpuservice.instanceType.localStorage.tip': 'Maximum available disk',
   'gpuservice.instanceType.notSliceable': 'Not Sliceable',
-  'gpuservice.instanceType.filter.name': 'Search by name',
+  'gpuservice.instanceType.filter.name': 'Ada göre ara',
   'gpuservice.instanceType.clusterUnavailable':
     'Küme yanıt vermedi; büyük olasılıkla hazır bir işçi düğümü yok. Kümeyi kontrol edip yeniden deneyin.',
   'gpuservice.instance.disk': 'Disk',


### PR DESCRIPTION
Refer to issues:
- https://github.com/gpustack/gpustack/issues/6104

The Instance Types search box is the one from gpustack#6104, and its placeholder key `gpuservice.instanceType.filter.name` was only ever written in `en-US` and `zh-CN`. In `ja-JP`, `ru-RU` and `tr-TR` it still held the literal English string `Search by name`, so those three locales fell back to English on a screen where everything around it is translated.

The three sibling placeholders — `gpuservice.storageType.filter.name`, `gpuservice.publicKey.filter.name` and `gpuservice.template.filter.name` — are translated in all five locales and already say this exact sentence, so this key takes their wording verbatim instead of inventing a second register for it:

| locale | sibling keys | this key, now |
| --- | --- | --- |
| `ja-JP` | 名前で検索 | 名前で検索 |
| `ru-RU` | Поиск по имени | Поиск по имени |
| `tr-TR` | Ada göre ara | Ada göre ara |

Note that `filter.name` splits into two phrasings across the codebase and this follows the right one: `storageType` / `publicKey` say *search*, while `template` says *filter* (`名前でフィルター` / `Фильтр по имени` / `Ada göre filtrele`). `instanceType` is `Search by name` in `en-US`, so it belongs with the first pair.

Not changed here: `gpuservice.instanceType.unitRam.tip`, `.localStorage`, `.localStorage.tip` and `.notSliceable` sit on the lines immediately above and are also untranslated in the same three locales. They are a separate omission from a different change and are left for a sweep of their own rather than folded into this one.
