### PR TITLE
fix(models): filter the three searchable selects by the label they show

### DIFF
--- a/src/pages/llmodels/forms/backend.tsx
+++ b/src/pages/llmodels/forms/backend.tsx
@@ -218,6 +218,11 @@ const BackendFields: React.FC = () => {
         <SealSelect
           required
           showSearch
+          // Without this the search filters on `value` (the backend name),
+          // which is not what the option shows for the built-in "custom"
+          // backend: its label is the translated "Custom", so typing that
+          // matched nothing in any locale but English.
+          optionFilterProp="label"
           onChange={handleOnBackendChange}
           label={intl.formatMessage({ id: 'models.form.backend' })}
           description={<TooltipList list={backendTipsList}></TooltipList>}
@@ -242,6 +247,10 @@ const BackendFields: React.FC = () => {
             allowClear
             showSearch
             allowNull
+            // The version options label themselves with their own value, but
+            // the leading "Auto" entry carries a null value, so the default
+            // filter (on `value`) can never match the word the option shows.
+            optionFilterProp="label"
             labelRender={backendVersionLabelRender}
             placeholder={intl.formatMessage({
               id: 'models.form.backendVersion.holder'

--- a/src/pages/llmodels/forms/vgpu-type.tsx
+++ b/src/pages/llmodels/forms/vgpu-type.tsx
@@ -480,6 +480,11 @@ const VGPUTypeForm: React.FC = () => {
       >
         <SealSelect
           showSearch
+          // Without this the search filters on `value` (the type's resource
+          // name) while the option renders its `label`, which leads with
+          // `status.detail.product`. Typing the product name shown in the
+          // dropdown would match nothing.
+          optionFilterProp="label"
           label={intl.formatMessage({ id: 'models.form.gpuType' })}
           options={typeOptions}
           optionRender={typeOptionRender}


### PR DESCRIPTION
Refer to issues:
- https://github.com/gpustack/gpustack/issues/6104

Follow-up sweep to gpustack-ui#1365, which fixed one searchable `Select` that filtered on a value the user never sees. The same defect can exist wherever `optionFilterProp` is unset, so this triages **every** searchable dropdown in `src/` and fixes the ones that are actually broken.

## The mechanism

Read out of the installed `@rc-component/select@1.6.15` (`es/hooks/useFilterOptions.js`) rather than from the docs:

```js
if (optionFilterProp && optionFilterProp.length) {          // unset -> normalized to [], skipped
  return optionFilterProp.some(prop => includes(option[prop], upperSearch));
}
if (option[fieldOptions]) {                                  // OptionGroup only
  return includes(option[fieldLabel !== 'children' ? fieldLabel : 'label'], upperSearch);
}
return includes(option[fieldValue], upperSearch);            // flat options -> filters by VALUE
```

So for flat `options`, an unset `optionFilterProp` filters by `value`. That is only a bug where the option's `label` differs from its `value` — which is the single test applied below.

## Fixed (3)

| site | label | value | why the default was wrong |
| --- | --- | --- | --- |
| `llmodels/forms/vgpu-type.tsx:482` | `status.detail.product \|\| name` | the type's resource name | The option's primary line renders exactly the label, so typing the product name the dropdown had just shown matched nothing. |
| `llmodels/forms/backend.tsx:220` | translated "Custom" for the built-in `custom` backend, else the backend name | `backend_name` | Matched in English by coincidence and in **no other locale** — `自定义` / `カスタム` / `Пользовательский` against a `custom` value. |
| `llmodels/forms/backend.tsx:243` | the version string; `Auto` for the leading entry | the version string; **`null`** for `Auto` | Every version option labels itself with its own value, so those were fine, but no search text can ever match a `null` value — the `Auto` entry was unreachable by search in every locale. |

The three now pass `optionFilterProp="label"`, matching the two in `gpu-service/instance-types/forms/index.tsx:173,222` and the one in `gpu-service/instances/forms/storage-volume.tsx` from #1365.

## Triaged as already-correct (19)

The grep for `showSearch` without a nearby `optionFilterProp` / `filterOption` returns 31 sites, but most of them cannot have this bug. Grouped by the reason, so the judgement is checkable rather than just counted:

**`showSearch={false}` — not searchable at all (9).** `llmodels/user-models.tsx:240,252`, `llmodels/filters/index.tsx:80,102,128`, `llmodels/instance-view/left-filters.tsx:63,76,90,106`. These matched the grep only because it keys on the prop name.

**Cascader — never used `optionFilterProp` (7).** `benchmark/forms/model-instance.tsx:215`, `llmodels/forms/schedule-type.tsx:290`, `model-routes/forms/targets.tsx:307,373`, `llmodels/components/download/target-form.tsx:231`, `usage/components/filter-bar.tsx:317`, `dashboard/components/usage-inner/filter-bar.tsx:129`. `rc-cascader@3.7.3`'s `useSearchOptions` has its own `defaultFilter`, which already matches on the path options' `label`:

```js
var defaultFilter = function (search, options, _ref) {
  var label = _ref.label;
  return options.some(function (opt) {
    return String(opt[label]).toLowerCase().includes(search.toLowerCase());
  });
};
```

**AutoComplete — does not filter at all (2).** `llmodels/forms/speculative-decode.tsx:173`, `cluster-management/components/pool-form.tsx:433`. antd's AutoComplete is `mode="combobox"`, and rc-select forces the filter off for it:

```js
const mergedFilterOption = React.useMemo(() => {
  if (filterOption === undefined && mode === 'combobox') { return false; }
  return filterOption;
}, [filterOption, mode]);
```

`useFilterOptions` then early-returns every option. Adding `optionFilterProp` there would be dead code. The draft-model picker searches server-side through `onSearch`; the OS image picker shows its whole list while you type, which is AutoComplete's normal behaviour and out of scope here.

**core-ui `SimpleSelect` — already filters by label (8).** `usage/events-tab/index.tsx:255`, `usage/components/filter-bar.tsx:281,297,354`, `usage/components/resource-filter-bar.tsx:208,224`, `kv-cache/components/service-deployments.tsx:200`, `service-monitor.tsx:211`. `SimpleSelect` overrides `showSearch` unconditionally, whatever the call site passes:

```js
showSearch: {
  onSearch: F,
  filterOption: (typeof showSearch === 'object' ? showSearch.filterOption : undefined)
    || ((input, opt) => opt.label.toLowerCase().includes(input.toLowerCase()))
}
```

This matters, because several of these **would** have been broken otherwise: the usage filters value their options with a synthetic `id:${id}` / `row:${index}` token (`usage/services/use-query-meta-data.ts`) and the resource filters with a numeric id (`usage/hooks/use-resource-meta.ts`), against human-readable labels. They are correct today only because of `SimpleSelect`, not because of the call sites.

**Label and value agree (3).** `playground/components/model-select.tsx:43` (both `item.id`), `kv-cache/components/service-deployments.tsx:200` and `service-monitor.tsx:211` (both the worker name — these are also SimpleSelect, so they are covered twice over).

## Verification

Verified end-to-end against a real GPUStack, with an A/B on the **same backend and the same data** — only the UI build differs. The "before" side is the `gpustack/gpustack:dev` image (which already carries #1365 and #1366 but not this PR); the "after" side is a local dev server proxying to that same server.

Environment: single-node k3s v1.34.9 on a host with 2 × AMD Radeon RX 7800 XT, `gpustack-operator` v0.8.5 (Kueue + NFD) deriving the InstanceTypes, one Docker cluster and one Kubernetes cluster registered.

| dropdown | typed | before (no #1367) | after (#1367) |
| --- | --- | --- | --- |
| backend (`backend.tsx:220`), zh-CN | `自定义` — the text the option shows | **暂无数据** | matches 自定义 |
| backend, zh-CN | `Custom` — the value, never shown | matches 自定义 | **暂无数据** (see below) |
| backend, zh-CN | `vllm` | matches vLLM | matches vLLM |
| backend version (`backend.tsx:243`), zh-CN | `自动` — the text the option shows | **暂无数据** | matches 自动 |
| GPU type (`vgpu-type.tsx:482`) | `AMD-Radeon-RX-7800-XT` — the text the option shows | **无可用的实例类型** | matches it |
| GPU type | `custom-tier-large` — the value, never shown | matches it | **无可用的实例类型** |

The root-cause data, straight off the API rather than inferred: `/v2/inference-backends/list` returns `backend_name: "Custom"`, and `backendOptionsMap.custom === 'Custom'`, so that one option gets `value='Custom'` against `label=intl('backend.custom')` — 自定义 / Пользовательский / Özel. It matched in English purely by coincidence.

### A behaviour change this introduces

Row 2 is not a regression in the filter, it is what `optionFilterProp="label"` *means*: filtering moves to the label and no longer also covers the value. Under a non-English locale you can no longer find the Custom backend by typing its English `Custom`. Every other backend is unaffected because its label and value are equal (row 3 confirms `vllm` → `vLLM` still matches, case-insensitively).

Keeping the plain `"label"` form is deliberate: it matches the three call sites already on `main`, and searching by the text on screen is the primary case while searching the value is an implementation detail leaking through. `optionFilterProp` does accept an array (`optionFilterProp.some(...)` in rc-select), so `['label','value']` would be a strict superset if a reviewer prefers no behaviour change at all — that choice applies equally to the three sites already merged, so it belongs in one sweep rather than here.

### Scope note on the GPU type picker

The bug only bites when the InstanceType's name is unrelated to its product. For the pools the operator **derives**, it is not reachable: the derived name `gpustack--amd-radeon-rx-7800-xt-linux-amd64` happens to contain the kebab form of its own product, so `includes(value, "AMD-RADEON-RX-7800-XT")` is true and the value filter matches by accident.

The row above was produced with `custom-tier-large` — an admin-authored InstanceType referencing a catalog flavor by `acceleratorGroup`, exactly the shape the [walkthrough](https://github.com/gpustack/gpustack/blob/main/docs/walkthrough.md) documents under "Managing a custom InstanceType". Its `status.detail.product` is `AMD-Radeon-RX-7800-XT` while its name is `custom-tier-large`, and it wins the flavor dedup on name order, so it is the option the dropdown renders. That is the realistic case where an operator cannot find the GPU the picker is showing them.

`npx tsc --noEmit` holds at the pre-existing 54 errors; prettier and eslint clean.

## Note

`optionFilterProp` is marked `@deprecated` on rc-select's props in favour of `showSearch.optionFilterProp`. This PR keeps the top-level form to match the three call sites already on `main`; migrating that spelling is a separate, whole-codebase change and does not belong in a fix.
