### PR TITLE
feat: management console link and benchmark cache-service row

### DIFF
--- a/src/locales/en-US/benchmark.ts
+++ b/src/locales/en-US/benchmark.ts
@@ -362,6 +362,7 @@ export default {
     'Concurrency {rate} sustains {tps} tok/s{prev, select, yes{ — {prevUp}% more throughput than {prevRate}} other{}}{next, select, yes{; pushing to {nextRate} adds only {nextUp}% throughput but {nextTtftUp}% TTFT} other{}}. That makes {rate} the best operating point{slo, select, yes{, within the SLO} other{}}.',
   'benchmark.detail.modelFile': 'Model File',
   'benchmark.detail.kvCache': 'Extended KV Cache',
+  'benchmark.detail.cacheService': 'Cache Service',
   'benchmark.detail.speculativeDecoding': 'Speculative Decoding',
   'benchmark.detail.inputOutputTokenLength': 'Token Length (Input/Output)',
   'benchmark.env.gpuName': 'GPU Name',

--- a/src/locales/en-US/kv-cache.ts
+++ b/src/locales/en-US/kv-cache.ts
@@ -40,6 +40,11 @@ export default {
   'kvCache.form.workerSelector.tips':
     'Runs one instance on each worker matching all labels; leave empty to cover every worker.',
   'kvCache.form.chunkSize': 'Chunk Size',
+  'kvCache.form.managementUrl': 'Management URL',
+  'kvCache.form.managementUrl.tips':
+    'Link to the engine-provided management UI; shown as a link beside the service name',
+  'kvCache.form.managementUrl.invalid': 'Enter a valid http(s) URL',
+  'kvCache.button.management': 'Management URL',
   'kvCache.form.chunkSize.tips':
     'Tokens per KV cache chunk. Smaller chunks enable finer-grained reuse at higher overhead. Leave empty to use the engine default.',
   'kvCache.form.advanced': 'Advanced',

--- a/src/locales/ja-JP/benchmark.ts
+++ b/src/locales/ja-JP/benchmark.ts
@@ -361,6 +361,7 @@ export default {
     '並行 {rate} は {tps} tok/s を安定して出力します{prev, select, yes{。{prevRate} よりスループット +{prevUp}%} other{}}{next, select, yes{。{nextRate} まで上げてもスループットは +{nextUp}% のみ、TTFT は +{nextTtftUp}%} other{}}。したがって {rate} が最適な動作点です{slo, select, yes{(SLO 内)} other{}}。',
   'benchmark.detail.modelFile': 'Model File',
   'benchmark.detail.kvCache': 'Extended KV Cache',
+  'benchmark.detail.cacheService': 'Cache Service',
   'benchmark.detail.speculativeDecoding': 'Speculative Decoding',
   'benchmark.detail.inputOutputTokenLength': 'Token Length (Input/Output)',
   'benchmark.env.gpuName': 'GPU Name',

--- a/src/locales/ja-JP/kv-cache.ts
+++ b/src/locales/ja-JP/kv-cache.ts
@@ -40,6 +40,11 @@ export default {
   'kvCache.form.workerSelector.tips':
     'Runs one instance on each worker matching all labels; leave empty to cover every worker.',
   'kvCache.form.chunkSize': 'Chunk Size',
+  'kvCache.form.managementUrl': 'Management URL',
+  'kvCache.form.managementUrl.tips':
+    'Link to the engine-provided management UI; shown as a link beside the service name',
+  'kvCache.form.managementUrl.invalid': 'Enter a valid http(s) URL',
+  'kvCache.button.management': 'Management URL',
   'kvCache.form.chunkSize.tips':
     'Tokens per KV cache chunk. Smaller chunks enable finer-grained reuse at higher overhead. Leave empty to use the engine default.',
   'kvCache.form.advanced': 'Advanced',

--- a/src/locales/ru-RU/benchmark.ts
+++ b/src/locales/ru-RU/benchmark.ts
@@ -369,6 +369,7 @@ export default {
     'Параллелизм {rate} обеспечивает {tps} tok/s{prev, select, yes{ — на {prevUp}% больше, чем {prevRate}} other{}}{next, select, yes{; переход к {nextRate} добавляет лишь {nextUp}% пропускной способности, но {nextTtftUp}% к TTFT} other{}}. Поэтому {rate} — оптимальная рабочая точка{slo, select, yes{, в рамках SLO} other{}}.',
   'benchmark.detail.modelFile': 'Model File',
   'benchmark.detail.kvCache': 'Extended KV Cache',
+  'benchmark.detail.cacheService': 'Cache Service',
   'benchmark.detail.speculativeDecoding': 'Speculative Decoding',
   'benchmark.detail.inputOutputTokenLength': 'Token Length (Input/Output)',
   'benchmark.env.gpuName': 'GPU Name',

--- a/src/locales/ru-RU/kv-cache.ts
+++ b/src/locales/ru-RU/kv-cache.ts
@@ -40,6 +40,11 @@ export default {
   'kvCache.form.workerSelector.tips':
     'Runs one instance on each worker matching all labels; leave empty to cover every worker.',
   'kvCache.form.chunkSize': 'Chunk Size',
+  'kvCache.form.managementUrl': 'Management URL',
+  'kvCache.form.managementUrl.tips':
+    'Link to the engine-provided management UI; shown as a link beside the service name',
+  'kvCache.form.managementUrl.invalid': 'Enter a valid http(s) URL',
+  'kvCache.button.management': 'Management URL',
   'kvCache.form.chunkSize.tips':
     'Tokens per KV cache chunk. Smaller chunks enable finer-grained reuse at higher overhead. Leave empty to use the engine default.',
   'kvCache.form.advanced': 'Advanced',

--- a/src/locales/tr-TR/benchmark.ts
+++ b/src/locales/tr-TR/benchmark.ts
@@ -363,6 +363,7 @@ export default {
     'Eşzamanlılık {rate}, {tps} tok/s sağlar{prev, select, yes{ — {prevRate} değerine göre %{prevUp} daha fazla verim} other{}}{next, select, yes{; {nextRate} değerine çıkmak verime yalnızca %{nextUp} eklerken TTFT %{nextTtftUp} artar} other{}}. Bu nedenle {rate} en iyi çalışma noktasıdır{slo, select, yes{, SLO içinde} other{}}.',
   'benchmark.detail.modelFile': 'Model Dosyası',
   'benchmark.detail.kvCache': 'Genişletilmiş KV Önbellek',
+  'benchmark.detail.cacheService': 'Cache Service',
   'benchmark.detail.speculativeDecoding': 'Spekülatif Çözümleme',
   'benchmark.detail.inputOutputTokenLength': 'Token Uzunluğu (Giriş/Çıkış)',
   'benchmark.env.gpuName': 'GPU Adı',

--- a/src/locales/tr-TR/kv-cache.ts
+++ b/src/locales/tr-TR/kv-cache.ts
@@ -40,6 +40,11 @@ export default {
   'kvCache.form.workerSelector.tips':
     'Runs one instance on each worker matching all labels; leave empty to cover every worker.',
   'kvCache.form.chunkSize': 'Chunk Size',
+  'kvCache.form.managementUrl': 'Management URL',
+  'kvCache.form.managementUrl.tips':
+    'Link to the engine-provided management UI; shown as a link beside the service name',
+  'kvCache.form.managementUrl.invalid': 'Enter a valid http(s) URL',
+  'kvCache.button.management': 'Management URL',
   'kvCache.form.chunkSize.tips':
     'Tokens per KV cache chunk. Smaller chunks enable finer-grained reuse at higher overhead. Leave empty to use the engine default.',
   'kvCache.form.advanced': 'Advanced',

--- a/src/locales/zh-CN/benchmark.ts
+++ b/src/locales/zh-CN/benchmark.ts
@@ -357,6 +357,7 @@ export default {
     '并发 {rate} 可稳定输出 {tps} tok/s{prev, select, yes{,相比 {prevRate} 吞吐 +{prevUp}%} other{}}{next, select, yes{;继续加到 {nextRate} 吞吐仅 +{nextUp}% 而 TTFT +{nextTtftUp}%} other{}}。因此 {rate} 是最佳运行点{slo, select, yes{,且满足 SLO} other{}}。',
   'benchmark.detail.modelFile': '模型文件',
   'benchmark.detail.kvCache': '扩展 KV 缓存',
+  'benchmark.detail.cacheService': '缓存服务',
   'benchmark.detail.speculativeDecoding': '推测解码',
   'benchmark.detail.inputOutputTokenLength': 'Token 长度 (输入/输出)',
   'benchmark.env.gpuName': 'GPU 名称',

--- a/src/locales/zh-CN/kv-cache.ts
+++ b/src/locales/zh-CN/kv-cache.ts
@@ -37,6 +37,11 @@ export default {
   'kvCache.form.workerSelector.tips':
     '在匹配全部标签的每个节点上各运行一个实例;留空则覆盖所有节点。',
   'kvCache.form.chunkSize': '块大小',
+  'kvCache.form.managementUrl': '管理地址',
+  'kvCache.form.managementUrl.tips':
+    '缓存引擎自带管理界面的链接，将显示为服务名称旁的跳转链接',
+  'kvCache.form.managementUrl.invalid': '请输入合法的 http(s) 地址',
+  'kvCache.button.management': '管理地址',
   'kvCache.form.chunkSize.tips':
     '每个 KV 缓存块的 token 数。块越小复用粒度越细，但开销越高。留空使用引擎默认值。',
   'kvCache.form.advanced': '高级配置',

--- a/src/pages/benchmark/components/summary/instance.tsx
+++ b/src/pages/benchmark/components/summary/instance.tsx
@@ -6,8 +6,6 @@ import { useDetailContext } from '../../config/detail-context';
 const Instance: React.FC = () => {
   const intl = useIntl();
   const { detailData } = useDetailContext();
-  const [, instanceData] =
-    Object.entries(detailData?.snapshot?.instances || {})[0] || [];
 
   const items = useMemo(() => {
     const { snapshot } = detailData;
@@ -91,6 +89,20 @@ const Instance: React.FC = () => {
           <Flex gap={8} wrap="wrap">
             {instanceData?.extended_kv_cache?.enabled ? (
               <>
+                {instanceData?.extended_kv_cache?.mode === 'shared' && (
+                  <span className="flex-center">
+                    <span>
+                      {intl.formatMessage({
+                        id: 'benchmark.detail.cacheService'
+                      })}
+                      :
+                    </span>
+                    <span>
+                      {instanceData?.cache_service_name ||
+                        `#${instanceData?.extended_kv_cache?.cache_service_id}`}
+                    </span>
+                  </span>
+                )}
                 {instanceData?.extended_kv_cache?.ram_ratio && (
                   <span className="flex-center">
                     <span>

--- a/src/pages/benchmark/config/detail-types.ts
+++ b/src/pages/benchmark/config/detail-types.ts
@@ -33,6 +33,9 @@ export interface InstancesData {
   run_command: any;
   env: any;
   extended_kv_cache: any;
+  // snapshot-stored name of the attached shared cache service; kept so
+  // the benchmark keeps naming it after the service is deleted
+  cache_service_name?: string;
   speculative_config: any;
   subordinate_workers: any[];
 }

--- a/src/pages/benchmark/hooks/use-column-settings.tsx
+++ b/src/pages/benchmark/hooks/use-column-settings.tsx
@@ -21,6 +21,7 @@ const allFields = [
   'profile',
   'dataset_name',
   'gpu_summary',
+  'cache_service',
   'state',
   'recommended_rate',
   'validity',
@@ -479,6 +480,29 @@ const useColumnSettings = (options: {
           {text}
         </AutoTooltip>
       )
+    },
+    {
+      title: renderTitle(
+        intl.formatMessage({ id: 'benchmark.detail.cacheService' })
+      ),
+      dataIndex: 'cache_service',
+      width: 140,
+      render: (_text: unknown, record: ListItem) => {
+        // the snapshot keeps naming the service after it is deleted;
+        // older snapshots without the name fall back to #id
+        const instance: any = Object.values(
+          (record as any).snapshot?.instances || {}
+        )[0];
+        const kv = instance?.extended_kv_cache;
+        if (!kv?.enabled || kv?.mode !== 'shared') {
+          return '-';
+        }
+        return (
+          <AutoTooltip ghost minWidth={20}>
+            {instance?.cache_service_name || `#${kv?.cache_service_id}`}
+          </AutoTooltip>
+        );
+      }
     },
     {
       title: renderTitle(intl.formatMessage({ id: 'common.table.status' })),

--- a/src/pages/kv-cache/components/service-overview.tsx
+++ b/src/pages/kv-cache/components/service-overview.tsx
@@ -1,24 +1,23 @@
+import { ExportOutlined } from '@ant-design/icons';
 import {
   AutoTooltip,
   CardWrapper,
   IconFont,
-  StatusTag,
-  ThemeTag
+  StatusTag
 } from '@gpustack/core-ui';
 import { useIntl } from '@umijs/max';
 import type { DescriptionsProps } from 'antd';
-import { Button, Descriptions, Space } from 'antd';
+import { Button, Descriptions, Space, Tooltip, Typography } from 'antd';
 import dayjs from 'dayjs';
 import React from 'react';
 import styled from 'styled-components';
 import {
-  ServiceModeColorMap,
-  ServiceModeMap,
   ServiceModeValueMap,
   ServiceStateLabelMap,
   ServiceStatus,
   canViewServiceLogs,
-  formatServiceVersion
+  formatServiceVersion,
+  isHttpUrl
 } from '../config';
 import {
   CacheProviderItem,
@@ -226,12 +225,24 @@ const ServiceOverview: React.FC<ServiceOverviewProps> = ({
             title={
               <Title>
                 <span>{data.name}</span>
-                <ThemeTag
-                  color={ServiceModeColorMap[data.mode] || 'blue'}
-                  opacity={0.7}
-                >
-                  {intl.formatMessage({ id: ServiceModeMap[data.mode] })}
-                </ThemeTag>
+                {isHttpUrl(data.config?.management_url) && (
+                  <Tooltip
+                    title={intl.formatMessage({
+                      id: 'kvCache.button.management'
+                    })}
+                  >
+                    <Typography.Link
+                      href={data.config?.management_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={intl.formatMessage({
+                        id: 'kvCache.button.management'
+                      })}
+                    >
+                      <ExportOutlined style={{ fontSize: 13 }} />
+                    </Typography.Link>
+                  </Tooltip>
+                )}
               </Title>
             }
             extra={

--- a/src/pages/kv-cache/config/index.ts
+++ b/src/pages/kv-cache/config/index.ts
@@ -79,6 +79,10 @@ export const canViewServiceLogs = (
 export const canViewInstanceLogs = (instance: CacheServiceInstanceItem) =>
   logViewableStates.includes(instance.state);
 
+// hrefs built from stored config must never carry a javascript: scheme
+export const isHttpUrl = (url?: string | null): boolean =>
+  !!url && /^https?:\/\//i.test(url);
+
 // The reserved "custom" version says nothing by itself, so it is shown with
 // the image the service actually runs.
 export const formatServiceVersion = (

--- a/src/pages/kv-cache/config/types.ts
+++ b/src/pages/kv-cache/config/types.ts
@@ -79,6 +79,8 @@ export interface CacheProviderItem {
   icon?: string;
   links?: CacheProviderLink[];
   supported_modes: ServiceMode[];
+  // the engine ships its own management UI: the form offers management_url
+  management_url?: boolean;
   // managed-mode instance layout: "singleton" runs one instance on the
   // worker picked at creation; "per_node" runs one on every worker
   topology?: 'singleton' | 'per_node';
@@ -147,6 +149,8 @@ export interface ServiceConfig {
   // managed only; ordered by priority (reads prefer the first entry,
   // writes go to all); null or empty clears the L2 storage backends
   l2_storages?: L2StorageConfig[] | null;
+  // link to the cache engine's own management console (display-only)
+  management_url?: string;
 }
 
 export interface FormData {
@@ -170,6 +174,8 @@ export interface FormData {
     env?: Record<string, string>;
     fields?: Record<string, any>;
     l2_storages?: L2StorageConfig[] | null;
+    // link to the cache engine's own management console (display-only)
+    management_url?: string;
   };
   endpoint?: {
     host?: string;

--- a/src/pages/kv-cache/forms/index.tsx
+++ b/src/pages/kv-cache/forms/index.tsx
@@ -1,7 +1,8 @@
 import { PageAction } from '@/config';
 import { PageActionType } from '@/config/types';
-import { useQueryWorkerList } from '@/pages/resources/services/use-query-worker-list';
+import { useQueryClusterList } from '@/pages/cluster-management/services/use-query-cluster-list';
 import { ListItem as WorkerListItem } from '@/pages/resources/config/types';
+import { useQueryWorkerList } from '@/pages/resources/services/use-query-worker-list';
 import {
   ArrowDownOutlined,
   ArrowUpOutlined,
@@ -46,7 +47,6 @@ import {
   ServiceMode
 } from '../config/types';
 import useCacheProviders from '../hooks/use-cache-providers';
-import { useQueryClusterList } from '@/pages/cluster-management/services/use-query-cluster-list';
 
 const GroupTitle = styled.div`
   font-size: 14px;
@@ -747,6 +747,7 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
         currentData.config?.parameters?.length ||
         Object.keys(currentData.config?.env || {}).length ||
         currentData.config?.chunk_size != null ||
+        currentData.config?.management_url ||
         currentData.restart_on_error === false
       ) {
         setAdvancedKeys(['advanced']);
@@ -1224,6 +1225,29 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
                 label: intl.formatMessage({ id: 'kvCache.form.advanced' }),
                 children: (
                   <>
+                    {(getProvider(providerName)?.management_url ||
+                      currentData?.config?.management_url) && (
+                      <Form.Item<FormData>
+                        name={['config', 'management_url']}
+                        rules={[
+                          {
+                            pattern: /^https?:\/\/\S+$/i,
+                            message: intl.formatMessage({
+                              id: 'kvCache.form.managementUrl.invalid'
+                            })
+                          }
+                        ]}
+                      >
+                        <CInput.Input
+                          label={intl.formatMessage({
+                            id: 'kvCache.form.managementUrl'
+                          })}
+                          description={intl.formatMessage({
+                            id: 'kvCache.form.managementUrl.tips'
+                          })}
+                        />
+                      </Form.Item>
+                    )}
                     <Form.Item<FormData> name={['config', 'chunk_size']}>
                       <InputNumber
                         min={1}

--- a/src/pages/kv-cache/hooks/use-service-columns.tsx
+++ b/src/pages/kv-cache/hooks/use-service-columns.tsx
@@ -1,3 +1,4 @@
+import { ExportOutlined } from '@ant-design/icons';
 // columns.ts
 import { systemConfigAtom } from '@/atoms/system';
 import { tableSorter } from '@/config/settings';
@@ -9,12 +10,13 @@ import {
   ThemeTag
 } from '@gpustack/core-ui';
 import { useIntl } from '@umijs/max';
-import { Typography } from 'antd';
+import { Tooltip, Typography } from 'antd';
 import { ColumnsType } from 'antd/lib/table';
 import dayjs from 'dayjs';
 import { useAtomValue } from 'jotai';
 import { useMemo } from 'react';
 import {
+  isHttpUrl,
   rowActionList,
   ServiceModeColorMap,
   ServiceModeMap,
@@ -77,11 +79,30 @@ const useServiceColumns = (
         sorter: tableSorter(1),
         minWidth: serviceColumnMinWidths.name,
         render: (text: string, record: ListItem) => (
-          <AutoTooltip ghost title={text}>
-            <Typography.Link onClick={() => onCellClick?.(record)}>
-              {text}
-            </Typography.Link>
-          </AutoTooltip>
+          <span className="flex-center" style={{ gap: 8 }}>
+            <AutoTooltip ghost title={text}>
+              <Typography.Link onClick={() => onCellClick?.(record)}>
+                {text}
+              </Typography.Link>
+            </AutoTooltip>
+            {isHttpUrl(record.config?.management_url) && (
+              <Tooltip
+                title={intl.formatMessage({ id: 'kvCache.button.management' })}
+              >
+                <Typography.Link
+                  href={record.config?.management_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={intl.formatMessage({
+                    id: 'kvCache.button.management'
+                  })}
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <ExportOutlined style={{ fontSize: 12 }} />
+                </Typography.Link>
+              </Tooltip>
+            )}
+          </span>
         )
       },
       {


### PR DESCRIPTION
Backend PR: https://github.com/gpustack/gpustack/pull/6160

A managed cache service may carry the URL of its engine's own console (e.g. the MeshFusion UI) in the advanced section; the detail page renders it as a new-tab button, and editing auto-expands the section when one is set. The benchmark instance summary names the attached shared cache service (the snapshot stores only the id; a deleted service falls back to #id) beside the existing in-process fields.