### PR TITLE
feat(clusters): point the credential hint at the provider sign-in page

### DIFF
--- a/src/locales/en-US/clusters.ts
+++ b/src/locales/en-US/clusters.ts
@@ -13,6 +13,8 @@ export default {
   'clusters.button.addNodePool': 'Add Worker Pool',
   'clusters.button.add.credential': 'Add {provider} Credential',
   'clusters.credential.title': 'Cloud Credential',
+  'clusters.credential.signinToCreate':
+    'No {name} yet? <a href="{link}" target="_blank">Sign in or sign up</a> to create one.',
   'clusters.credential.token': 'Access Token',
   'clusters.workerpool.region': 'Region',
   'clusters.workerpool.zone': 'Zone',
@@ -108,8 +110,6 @@ export default {
   'clusters.addworker.cacheVolume.holder':
     'e.g. /data/cache (path must start with /)',
   'clusters.addworker.vendorNotes.title': 'Notes for {vendor} Device',
-  'clusters.button.genToken':
-    'Need to create a new token? Click <a href="{link}" target="_blank">here</a>.',
   'clusters.addworker.amdNotes-01': `If the <span class="bold-text">/opt/rocm</span> directory does not exist, please create a symbolic link pointing to the ROCm installed path: <span class="bold-text">ln -s /path/to/rocm /opt/rocm</span>.`,
   'clusters.addworker.message.success_single':
     '{count} new worker has been added to the cluster.',

--- a/src/locales/ja-JP/clusters.ts
+++ b/src/locales/ja-JP/clusters.ts
@@ -13,6 +13,8 @@ export default {
   'clusters.button.addNodePool': 'Add Worker Pool',
   'clusters.button.add.credential': 'Add {provider} Credential',
   'clusters.credential.title': 'Cloud Credential',
+  'clusters.credential.signinToCreate':
+    'No {name} yet? <a href="{link}" target="_blank">Sign in or sign up</a> to create one.',
   'clusters.credential.token': 'Access Token',
   'clusters.workerpool.region': 'Region',
   'clusters.workerpool.zone': 'Zone',
@@ -108,8 +110,6 @@ export default {
   'clusters.addworker.cacheVolume.holder':
     'e.g. /data/cache (path must start with /)',
   'clusters.addworker.vendorNotes.title': 'Notes for {vendor} Device',
-  'clusters.button.genToken':
-    'Need to create a new token? Click <a href="{link}" target="_blank">here</a>.',
   'clusters.addworker.amdNotes-01': `If the <span class="bold-text">/opt/rocm</span> directory does not exist, please create a symbolic link pointing to the ROCm installed path: <span class="bold-text">ln -s /path/to/rocm /opt/rocm</span>.`,
   'clusters.addworker.message.success_single':
     '{count} new worker has been added to the cluster.',

--- a/src/locales/ru-RU/clusters.ts
+++ b/src/locales/ru-RU/clusters.ts
@@ -13,6 +13,8 @@ export default {
   'clusters.button.addNodePool': 'Добавить пул воркеров',
   'clusters.button.add.credential': 'Добавить аккаунт {provider}',
   'clusters.credential.title': 'Учетные данные',
+  'clusters.credential.signinToCreate':
+    '{name}: <a href="{link}" target="_blank">войдите или зарегистрируйтесь</a>, чтобы создать.',
   'clusters.credential.token': 'Токен доступа',
   'clusters.workerpool.region': 'Регион',
   'clusters.workerpool.zone': 'Зона',
@@ -108,8 +110,6 @@ export default {
   'clusters.addworker.cacheVolume.holder':
     'e.g. /data/cache (path must start with /)',
   'clusters.addworker.vendorNotes.title': 'Примечания для устройств {vendor}',
-  'clusters.button.genToken':
-    'Нужен новый токен? Нажмите <a href="{link}" target="_blank">здесь</a>.',
   'clusters.addworker.amdNotes-01': `Если директория <span class="bold-text">/opt/rocm</span> не существует, создайте символическую ссылку на путь установки ROCm: <span class="bold-text">ln -s /путь/к/rocm /opt/rocm</span>.`,
   'clusters.addworker.message.success_single':
     '{count} новый воркер был добавлен в кластер.',

--- a/src/locales/tr-TR/clusters.ts
+++ b/src/locales/tr-TR/clusters.ts
@@ -13,6 +13,8 @@ export default {
   'clusters.button.addNodePool': 'İşçi Havuzu Ekle',
   'clusters.button.add.credential': '{provider} Kimlik Bilgisi Ekle',
   'clusters.credential.title': 'Bulut Kimlik Bilgisi',
+  'clusters.credential.signinToCreate':
+    'Henüz {name} yok mu? Oluşturmak için <a href="{link}" target="_blank">giriş yapın veya kaydolun</a>.',
   'clusters.credential.token': 'Erişim Anahtarı',
   'clusters.workerpool.region': 'Bölge',
   'clusters.workerpool.zone': 'Alan',
@@ -108,8 +110,6 @@ export default {
   'clusters.addworker.cacheVolume.holder':
     'örn. /data/cache (yol / ile başlamalıdır)',
   'clusters.addworker.vendorNotes.title': '{vendor} Cihaz Notları',
-  'clusters.button.genToken':
-    'Yeni token oluşturmanız mı gerekiyor? <a href="{link}" target="_blank">Buraya tıklayın</a>.',
   'clusters.addworker.amdNotes-01': `<span class="bold-text">/opt/rocm</span> dizini mevcut değilse, lütfen ROCm kurulum yoluna işaret eden sembolik bağlantı oluşturun: <span class="bold-text">ln -s /path/to/rocm /opt/rocm</span>.`,
   'clusters.addworker.message.success_single':
     '{count} yeni işçi düğüm kümeye eklendi.',

--- a/src/locales/zh-CN/clusters.ts
+++ b/src/locales/zh-CN/clusters.ts
@@ -13,6 +13,8 @@ export default {
   'clusters.button.addNodePool': '添加节点池',
   'clusters.button.add.credential': '添加 {provider} 凭证',
   'clusters.credential.title': '云凭证',
+  'clusters.credential.signinToCreate':
+    '还没有{name}？<a href="{link}" target="_blank">登录或注册</a>后创建。',
   'clusters.credential.token': '访问令牌',
   'clusters.workerpool.region': '区域',
   'clusters.workerpool.zone': '可用区',
@@ -105,8 +107,6 @@ export default {
   'clusters.addworker.cacheVolume.holder':
     '例如：/data/cache（路径需以 / 开头）',
   'clusters.addworker.vendorNotes.title': '{vendor}设备注意事项',
-  'clusters.button.genToken':
-    '需要创建令牌？点击<a href="{link}" target="_blank">这里</a>。',
   'clusters.addworker.amdNotes-01': `如果 <span class="bold-text">/opt/rocm</span> 目录不存在，请创建一个指向已安装 ROCm 路径的符号链接：
     <span class="bold-text">ln -s /path/to/rocm /opt/rocm</span>。`,
   'clusters.addworker.message.success_single':

--- a/src/pages/cluster-management/components/add-credential.tsx
+++ b/src/pages/cluster-management/components/add-credential.tsx
@@ -33,7 +33,9 @@ const AddModal: React.FC<AddModalProps> = ({
   const [form] = Form.useForm();
   const intl = useIntl();
   const { getRuleMessage } = useAppUtils();
-  // Shuihua calls its secret an API key, DigitalOcean an access token.
+  // Shuihua calls its secret an API key, DigitalOcean an access token, and
+  // they hand it out on different kinds of page — so both the field label and
+  // the hint below it come from the adapter.
   const { tokenDocUrl, secretLabelId } = getCloudProviderAdapter(provider);
 
   const handleSumit = () => {
@@ -91,30 +93,33 @@ const AddModal: React.FC<AddModalProps> = ({
                 message: getRuleMessage('input', secretLabelId)
               }
             ]}
+            // Where to get the secret, visible rather than behind the label's
+            // `?` tooltip: for a first-time user this link is the first step,
+            // and a hint that has to be discovered by hovering an icon is not
+            // one. A provider with no documented page shows nothing rather
+            // than linking nowhere.
+            extra={
+              tokenDocUrl ? (
+                <span
+                  className="font-size-12"
+                  dangerouslySetInnerHTML={{
+                    __html: intl.formatMessage(
+                      { id: 'clusters.credential.signinToCreate' },
+                      {
+                        link: tokenDocUrl,
+                        name: intl.formatMessage({ id: secretLabelId })
+                      }
+                    )
+                  }}
+                ></span>
+              ) : undefined
+            }
           >
             <CInput.Password
               label={intl.formatMessage({
                 id: secretLabelId
               })}
               required={action === PageAction.CREATE}
-              // Providers without a documented token page (Shuihua, for now)
-              // just drop the hint rather than link nowhere.
-              description={
-                tokenDocUrl ? (
-                  <span
-                    dangerouslySetInnerHTML={{
-                      __html: intl.formatMessage(
-                        {
-                          id: 'clusters.button.genToken'
-                        },
-                        {
-                          link: tokenDocUrl
-                        }
-                      )
-                    }}
-                  ></span>
-                ) : undefined
-              }
             ></CInput.Password>
           </Form.Item>
         )}

--- a/src/pages/cluster-management/config/cloud-providers.ts
+++ b/src/pages/cluster-management/config/cloud-providers.ts
@@ -108,7 +108,12 @@ export interface CloudProviderAdapter {
     list: OSImageOption[],
     instanceSpec: Record<string, any>
   ) => OSImageOption[];
-  /** Console page where the user generates the API token, if any. */
+  /**
+   * Where the user goes to create the secret, if the provider documents such
+   * a page — the console page itself when it survives an anonymous visit,
+   * otherwise sign-in. The hint linking to it names the secret from
+   * `secretLabelId`.
+   */
   tokenDocUrl?: string;
 }
 
@@ -243,6 +248,8 @@ const digitalOceanAdapter: CloudProviderAdapter = {
 
     return list;
   },
+  // Deep link: an authenticated user lands on the token page itself, and an
+  // anonymous one is bounced through login back to it.
   tokenDocUrl: 'https://cloud.digitalocean.com/account/api/tokens'
 };
 
@@ -322,7 +329,8 @@ const shuihuaAdapter: CloudProviderAdapter = {
       }),
   // Region-less, and no image is tied to a particular spec template, so the
   // full lists are already the node pool's options.
-  matchOSImages: (list) => list
+  matchOSImages: (list) => list,
+  tokenDocUrl: 'https://hub.do.top/cn/signin'
 };
 
 export const cloudProviderAdapters: Record<string, CloudProviderAdapter> = {


### PR DESCRIPTION
Refer to backend PR:
- https://github.com/gpustack/gpustack/pull/6164

Shuihua had no documented page for its API key, so the credential drawer showed no hint at all — a first-time user was left to find hub.do.top on their own. It now links to the console sign-in, where the key is created after logging in or registering.

That link is a sign-in page rather than a token page, which is also true of DigitalOcean's: an unauthenticated visitor to the token URL lands on the login screen anyway. So both providers now carry the sign-in URL and share one hint, parameterised by `secretLabelId` — "No Access Token yet?" for DigitalOcean, "No API Key yet?" for Shuihua — and a provider needs nothing but a URL to get correct copy.

Move the hint out of the label's `?` tooltip and under the field, where it is simply visible. For a first-time user this link is step one, and a hint that has to be discovered by hovering an icon is not one. The Russian copy leads with the noun instead of interpolating it after "Нет", which would require the genitive.