### PR TITLE
feat(models): download an instance's logs from every worker

### DIFF
--- a/src/locales/en-US/common.ts
+++ b/src/locales/en-US/common.ts
@@ -80,6 +80,7 @@ export default {
   'common.title.config': 'Configuration',
   'common.message.fail': 'Failed!',
   'common.message.success': 'Succeed!',
+  'common.message.downloadFailed': 'Download failed',
   'common.delete.tips': 'Are you sure you want to delete?',
   'common.button.close': 'Close',
   'common.button.done': 'Done',

--- a/src/locales/en-US/models.ts
+++ b/src/locales/en-US/models.ts
@@ -371,6 +371,7 @@ export default {
   'models.instance.startHistory': 'Run History',
   'models.instance.startHistory.tips':
     'Shows logs from the run before the last error-triggered restart.',
+  'models.instance.logs.downloading': 'Downloading… {size}',
   'models.form.lora.label': 'LoRA Adapters',
   'models.form.lora.add': 'Add LoRA Adapter',
   'models.form.lora.select': 'Select LoRA',

--- a/src/locales/ja-JP/common.ts
+++ b/src/locales/ja-JP/common.ts
@@ -80,6 +80,7 @@ export default {
   'common.title.config': '設定',
   'common.message.fail': '失敗！',
   'common.message.success': '成功！',
+  'common.message.downloadFailed': 'ダウンロードに失敗しました',
   'common.delete.tips': '本当に削除しますか？',
   'common.button.close': '閉じる',
   'common.button.done': '完了',

--- a/src/locales/ja-JP/models.ts
+++ b/src/locales/ja-JP/models.ts
@@ -372,6 +372,7 @@ export default {
   'models.instance.startHistory': 'Run History',
   'models.instance.startHistory.tips':
     'Shows logs from the run before the last error-triggered restart.',
+  'models.instance.logs.downloading': 'ダウンロード中… {size}',
   'models.form.lora.label': 'LoRA Adapters',
   'models.form.lora.add': 'Add LoRA Adapter',
   'models.form.lora.select': 'Select LoRA',

--- a/src/locales/ru-RU/common.ts
+++ b/src/locales/ru-RU/common.ts
@@ -80,6 +80,7 @@ export default {
   'common.title.config': 'Конфигурация',
   'common.message.fail': 'Ошибка!',
   'common.message.success': 'Успешно!',
+  'common.message.downloadFailed': 'Не удалось скачать',
   'common.delete.tips': 'Вы уверены, что хотите удалить?',
   'common.button.close': 'Закрыть',
   'common.button.done': 'Готово',

--- a/src/locales/ru-RU/models.ts
+++ b/src/locales/ru-RU/models.ts
@@ -375,6 +375,7 @@ export default {
   'models.instance.startHistory': 'Run History',
   'models.instance.startHistory.tips':
     'Shows logs from the run before the last error-triggered restart.',
+  'models.instance.logs.downloading': 'Загрузка… {size}',
   'models.form.lora.label': 'LoRA Adapters',
   'models.form.lora.add': 'Add LoRA Adapter',
   'models.form.lora.select': 'Select LoRA',

--- a/src/locales/tr-TR/common.ts
+++ b/src/locales/tr-TR/common.ts
@@ -80,6 +80,7 @@ export default {
   'common.title.config': 'Yapılandırma',
   'common.message.fail': 'Başarısız!',
   'common.message.success': 'Başarılı!',
+  'common.message.downloadFailed': 'İndirme başarısız',
   'common.delete.tips': 'Silmek istediğinizden emin misiniz?',
   'common.button.close': 'Kapat',
   'common.button.done': 'Tamam',

--- a/src/locales/tr-TR/models.ts
+++ b/src/locales/tr-TR/models.ts
@@ -371,6 +371,7 @@ export default {
   'models.instance.startHistory': 'Çalıştırma Geçmişi',
   'models.instance.startHistory.tips':
     'Hata kaynaklı son yeniden başlatmadan önceki çalıştırmanın günlüklerini gösterir.',
+  'models.instance.logs.downloading': 'İndiriliyor… {size}',
   'models.form.lora.label': 'LoRA Adaptörleri',
   'models.form.lora.add': 'LoRA Adaptörü Ekle',
   'models.form.lora.select': 'LoRA Seç',

--- a/src/locales/zh-CN/common.ts
+++ b/src/locales/zh-CN/common.ts
@@ -74,6 +74,7 @@ export default {
   'common.edit.fail': '编辑失败',
   'common.message.fail': '失败!',
   'common.message.success': '成功!',
+  'common.message.downloadFailed': '下载失败',
   'common.delete.tips': '是否确定删除？',
   'common.button.close': '关闭',
   'common.button.done': '完成',

--- a/src/locales/zh-CN/models.ts
+++ b/src/locales/zh-CN/models.ts
@@ -352,6 +352,7 @@ export default {
   'models.instance.startHistory': '运行记录',
   'models.instance.startHistory.tips':
     '显示上一次因错误自动重启之前的那次运行的日志。',
+  'models.instance.logs.downloading': '正在下载… {size}',
   'models.form.lora.label': 'LoRA 适配器',
   'models.form.lora.add': '添加 LoRA 适配器',
   'models.form.lora.select': '选择 LoRA',

--- a/src/pages/llmodels/apis/index.ts
+++ b/src/pages/llmodels/apis/index.ts
@@ -176,6 +176,40 @@ export async function queryModelInstanceRestartCount(id: number) {
   });
 }
 
+/**
+ * Download an instance's complete logs across every worker and container.
+ *
+ * `responseType: 'blob'` keeps the bytes intact: one log stream comes back as
+ * text/plain, but several come back zipped, and decoding a zip as text destroys
+ * it. `getResponse` keeps the headers reachable, because the server owns the
+ * filename — and therefore the extension — via Content-Disposition.
+ *
+ * `skipErrorHandler`: on failure `response.data` is a Blob the global handler
+ * cannot read, so it would only ever show axios's own "Request failed with
+ * status code 502"; the caller reads the body itself instead. The 401 -> login
+ * redirect sits outside that guard in `request-config.tsx`, so session expiry is
+ * still handled.
+ *
+ * The response streams without a Content-Length, so `onDownloadProgress` gets a
+ * ProgressEvent whose `total` is meaningless — only `loaded` is usable.
+ */
+export async function downloadModelInstanceLogs(
+  id: number | string,
+  options?: {
+    signal?: AbortSignal;
+    onDownloadProgress?: (event: ProgressEvent) => void;
+  }
+): Promise<{ data: Blob; headers: Record<string, any> }> {
+  return request(`${MODEL_INSTANCE_API}/${id}/logs/download`, {
+    method: 'GET',
+    responseType: 'blob',
+    getResponse: true,
+    skipErrorHandler: true,
+    signal: options?.signal,
+    onDownloadProgress: options?.onDownloadProgress
+  });
+}
+
 // ===================== Model Instances end =====================
 
 // ===================== call huggingface quicksearch api =====================

--- a/src/pages/llmodels/components/instance-cells/actions-cell.tsx
+++ b/src/pages/llmodels/components/instance-cells/actions-cell.tsx
@@ -1,15 +1,7 @@
+import useDownloadInstanceLogs from '@/pages/llmodels/hooks/use-download-instance-logs';
 import { useBenchmarkTargetInstance } from '@/pages/llmodels/hooks/use-run-benchmark';
 import { DeleteOutlined, DownloadOutlined } from '@ant-design/icons';
-import {
-  DropdownButtons,
-  type HandlerOptions,
-  IconFont,
-  useDownloadStream
-} from '@gpustack/core-ui';
-import { useIntl } from '@umijs/max';
-import { Progress, notification } from 'antd';
-import dayjs from 'dayjs';
-import { MODEL_INSTANCE_API } from '../../apis';
+import { DropdownButtons, IconFont } from '@gpustack/core-ui';
 import { InstanceStatusMap, modelCategoriesMap } from '../../config';
 import { ListItem, ModelInstanceListItem } from '../../config/types';
 
@@ -66,64 +58,13 @@ const ActionsCell: React.FC<ActionsCellProps> = ({
   onSelect
 }) => {
   const { runBenchmarkOnInstance } = useBenchmarkTargetInstance();
-  const [api, contextHolder] = notification.useNotification({
-    stack: { threshold: 1 }
-  });
-  const { downloadStream } = useDownloadStream();
-  const intl = useIntl();
-
-  const createFileName = (name: string) => {
-    const timestamp = dayjs().format('YYYY-MM-DD_HH-mm-ss');
-    const fileName = `${name}_${timestamp}.txt`;
-    return fileName;
-  };
-
-  const renderMessage = (title: string) => {
-    return (
-      <div
-        style={{
-          width: 280,
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap',
-          overflow: 'hidden'
-        }}
-      >
-        {title}
-      </div>
-    );
-  };
-
-  const downloadNotification = (
-    data: HandlerOptions & {
-      filename: string;
-      duration?: number;
-      chunkRequestRef: any;
-    }
-  ) => {
-    api.open({
-      duration: data.duration,
-      title: renderMessage(data.filename),
-      key: data.filename,
-      closeIcon: (
-        <span>{intl.formatMessage({ id: 'common.button.cancel' })}</span>
-      ),
-      description: <Progress percent={data.percent} size="small"></Progress>,
-      onClose() {
-        data.chunkRequestRef?.current?.abort();
-        notification.destroy?.(data.filename);
-      }
-    });
-  };
+  const { downloadLogs } = useDownloadInstanceLogs();
 
   const handleOnSelect = (val: string) => {
     if (val === 'benchmark') {
       runBenchmarkOnInstance(record);
     } else if (val === 'download') {
-      downloadStream({
-        url: `${MODEL_INSTANCE_API}/${record.id}/logs`,
-        filename: createFileName(record.name),
-        downloadNotification
-      });
+      downloadLogs(record);
     } else {
       onSelect(val, record);
     }
@@ -143,13 +84,10 @@ const ActionsCell: React.FC<ActionsCellProps> = ({
   });
 
   return (
-    <>
-      {contextHolder}
-      <DropdownButtons
-        items={actionItems}
-        onSelect={handleOnSelect}
-      ></DropdownButtons>
-    </>
+    <DropdownButtons
+      items={actionItems}
+      onSelect={handleOnSelect}
+    ></DropdownButtons>
   );
 };
 

--- a/src/pages/llmodels/hooks/use-download-instance-logs.tsx
+++ b/src/pages/llmodels/hooks/use-download-instance-logs.tsx
@@ -1,0 +1,126 @@
+import { convertFileSize } from '@/utils';
+import { downloadFile, filenameFromDisposition } from '@/utils/download-stream';
+import { useIntl } from '@umijs/max';
+import { App } from 'antd';
+import { downloadModelInstanceLogs } from '../apis';
+import { ModelInstanceListItem as ListItem } from '../config/types';
+
+// A ProgressEvent fires every few milliseconds; reopening the notification on
+// every one of them is a re-render per tick for no readable gain.
+const PROGRESS_INTERVAL = 300;
+
+/**
+ * Instances currently downloading, app-wide — deliberately not a ref.
+ *
+ * ActionsCell renders per table row, so a ref would reset whenever a row
+ * unmounts and remounts (pagination, collapsing an expanded row). A second
+ * download started that way would collide with the first on the notification
+ * key below: it would overwrite the first's progress, and whichever finished
+ * first would `destroy` the survivor's still-live notification. The guard has
+ * to live in the same scope as the key it protects.
+ */
+const inFlight = new Set<number | string>();
+
+/**
+ * The failure body is FastAPI's own `{"detail": "..."}`: the download route
+ * raises Starlette's HTTPException, and gpustack registers a handler only for
+ * its own, so the usual `error.message` envelope never appears here.
+ */
+const readLogsError = async (error: any): Promise<string> => {
+  const body = error?.response?.data;
+  try {
+    const text = body instanceof Blob ? await body.text() : undefined;
+    const payload = text ? JSON.parse(text) : body;
+    return payload?.detail || payload?.error?.message || payload?.message || '';
+  } catch {
+    return '';
+  }
+};
+
+const useDownloadInstanceLogs = () => {
+  const intl = useIntl();
+  // Not notification.useNotification(): ActionsCell renders per table row, so a
+  // per-row contextHolder unmounts with its row — collapsing an expanded row or
+  // a list re-key would take the in-flight download's notification with it.
+  // <App component={false}> in layouts/index.tsx holds this one app-wide.
+  const { notification } = App.useApp();
+
+  const downloadLogs = async (record: ListItem) => {
+    // Checked and set synchronously, so two clicks in the same tick can't both
+    // get through the way a state flag would.
+    if (inFlight.has(record.id)) return;
+    inFlight.add(record.id);
+
+    // Keyed by instance, not by filename: the filename only arrives with the
+    // response headers, so it cannot identify the notification that precedes it.
+    const key = `instance-logs-${record.id}`;
+    const controller = new AbortController();
+    let lastTick = 0;
+
+    const openProgress = (loaded: number) => {
+      notification.open({
+        key,
+        // 0, not null: antd types duration as `number | false` and treats 0 as
+        // "never auto-close", which is what a download in progress needs.
+        duration: 0,
+        // `title`, not `message`: antd 6 deprecated `message` in favour of it.
+        title: record.name,
+        description: intl
+          .formatMessage(
+            { id: 'models.instance.logs.downloading' },
+            { size: convertFileSize(loaded, 1, true) }
+          )
+          .trim(),
+        closeIcon: (
+          <span>{intl.formatMessage({ id: 'common.button.cancel' })}</span>
+        ),
+        onClose: () => controller.abort()
+      });
+    };
+
+    openProgress(0);
+
+    try {
+      const { data, headers } = await downloadModelInstanceLogs(record.id, {
+        signal: controller.signal,
+        onDownloadProgress: (event) => {
+          const now = Date.now();
+          if (now - lastTick < PROGRESS_INTERVAL) return;
+          lastTick = now;
+          openProgress(event.loaded);
+        }
+      });
+
+      // The server owns the name, and with it the extension: .log for a single
+      // stream, .logs.zip once several workers are involved. Only the fallback
+      // has to guess, and it guesses from what the server actually sent.
+      const filename =
+        filenameFromDisposition(headers?.['content-disposition']) ||
+        `${record.name || `instance-${record.id}`}${
+          data.type?.includes('zip') ? '.logs.zip' : '.log'
+        }`;
+
+      notification.destroy(key);
+      downloadFile(data, filename);
+    } catch (error) {
+      // Read the flag BEFORE destroying: rc-notification's `close(key)` fires
+      // the notice's own `onClose`, so `destroy` would abort the controller and
+      // make every failure look like a cancellation — swallowing the error.
+      const cancelled = controller.signal.aborted;
+      notification.destroy(key);
+      // The user closed the notification. Not a failure — say nothing.
+      if (cancelled) return;
+      const detail = await readLogsError(error);
+      notification.error({
+        title: intl.formatMessage({ id: 'common.message.downloadFailed' }),
+        description: detail || undefined
+      });
+    } finally {
+      inFlight.delete(record.id);
+    }
+  };
+
+  return { downloadLogs };
+};
+
+export default useDownloadInstanceLogs;

--- a/src/utils/download-stream.ts
+++ b/src/utils/download-stream.ts
@@ -3,3 +3,29 @@ import { saveAs } from 'file-saver';
 export const downloadFile = (blob: Blob, filename: string) => {
   saveAs(blob, filename);
 };
+
+/**
+ * The filename a `Content-Disposition` header names (RFC 6266).
+ *
+ * `filename*` wins whenever it is present: that one carries the percent-encoded
+ * UTF-8 original, while the plain `filename` beside it is only the ASCII form
+ * the server degraded the name into. Reading the fallback first is exactly how a
+ * non-ASCII name turns into mojibake.
+ */
+export const filenameFromDisposition = (
+  disposition?: string | null
+): string => {
+  if (!disposition) return '';
+
+  const extended = disposition.match(/filename\*\s*=\s*UTF-8''([^;]+)/i);
+  if (extended) {
+    try {
+      return decodeURIComponent(extended[1].trim());
+    } catch {
+      // Malformed percent-encoding — fall through to the ASCII fallback.
+    }
+  }
+
+  const plain = disposition.match(/filename\s*=\s*(?:"([^"]*)"|([^;]+))/i);
+  return (plain?.[1] ?? plain?.[2] ?? '').trim();
+};


### PR DESCRIPTION
A distributed instance's log download only ever carried the main worker's log. The server now collects every worker and container behind `GET /model-instances/{id}/logs/download`, returning one .log when there is a single stream and a .logs.zip once there are several.

Swapping the URL alone would not do: the old path streamed through core-ui's `useDownloadStream`, which decodes the body as text, runs it through an ANSI-emulating worker and rebuilds a Blob under a client-side .txt name — that destroys a zip and ignores Content-Disposition. So the download becomes a blob request instead, letting the server own the filename and therefore the extension.

The endpoint streams without a Content-Length, so the percent bar would have sat at 0% forever; the notification now reports bytes received and stays cancellable. Its guard and its key both live at module / app scope, since ActionsCell renders per row and a per-row ref would let a remount start a second download that collides with the first on the same key.