### PR TITLE
feat(playground): add reasoning_effort param to chat settings

### DIFF
--- a/src/pages/playground/chat/params-config.ts
+++ b/src/pages/playground/chat/params-config.ts
@@ -124,6 +124,37 @@ export const ChatParamsConfig: ParamsSchema[] = [
     ]
   },
   {
+    type: 'Select',
+    name: 'reasoning_effort',
+    options: [
+      { label: 'None', value: 'none' },
+      { label: 'Minimal', value: 'minimal' },
+      { label: 'Low', value: 'low' },
+      { label: 'Medium', value: 'medium' },
+      { label: 'High', value: 'high' },
+      { label: 'XHigh', value: 'xhigh' },
+      { label: 'Max', value: 'max' }
+    ],
+    label: {
+      text: 'Reasoning Effort',
+      isLocalized: false
+    },
+    attrs: {
+      allowClear: true
+    },
+    formItemAttrs: {
+      // clearing the field must drop it from the request, not send an empty value
+      normalize(value: string) {
+        return value || undefined;
+      }
+    },
+    rules: [
+      {
+        required: false
+      }
+    ]
+  },
+  {
     type: 'InputNumber',
     name: 'seed',
     label: {

--- a/src/pages/playground/hooks/config.ts
+++ b/src/pages/playground/hooks/config.ts
@@ -49,7 +49,9 @@ export const llmInitialValues = {
   top_p: 1,
   max_tokens: 1024,
   frequency_penalty: 0,
-  presence_penalty: 0
+  presence_penalty: 0,
+  // no default reasoning effort, but the key must be here so switching model resets the field
+  reasoning_effort: undefined
 };
 
 export const advancedFieldsDefaultValus = {

--- a/src/pages/playground/hooks/use-init-llm.ts
+++ b/src/pages/playground/hooks/use-init-llm.ts
@@ -135,7 +135,9 @@ export const useInitLLmMeta = (
       if (changeValues.model) {
         return;
       }
-      setParams(allValues);
+
+      // a cleared optional param (e.g. reasoning_effort) is left out of the request
+      setParams(_.omitBy(allValues, _.isUndefined));
       setFormValues(allValues);
     }
   );

--- a/src/pages/resources/components/workers.tsx
+++ b/src/pages/resources/components/workers.tsx
@@ -285,7 +285,6 @@ const Workers: React.FC<WorkersProps> = ({ clusterId, source }) => {
           showSelect={source !== 'clusterDetail'}
           selectHolder={intl.formatMessage({ id: 'clusters.filterBy.cluster' })}
           marginBottom={22}
-          marginTop={30}
           buttonText={intl.formatMessage({ id: 'resources.button.create' })}
           handleDeleteByBatch={handleDeleteBatch}
           handleSearch={handleSearch}


### PR DESCRIPTION
Omit the field from the request when cleared, and reset it on model change.