### PR TITLE
feat(clusters): mount /opt/rocm/lib for AMD workers and note why

### DIFF
--- a/src/locales/en-US/clusters.ts
+++ b/src/locales/en-US/clusters.ts
@@ -111,6 +111,7 @@ export default {
     'e.g. /data/cache (path must start with /)',
   'clusters.addworker.vendorNotes.title': 'Notes for {vendor} Device',
   'clusters.addworker.amdNotes-01': `If the <span class="bold-text">/opt/rocm</span> directory does not exist, please create a symbolic link pointing to the ROCm installed path: <span class="bold-text">ln -s /path/to/rocm /opt/rocm</span>.`,
+  'clusters.addworker.amdNotes-02': `If multiple ROCm versions are managed on the host, you must mount <span class="bold-text">/opt/rocm/lib</span> to avoid detection failures.`,
   'clusters.addworker.message.success_single':
     '{count} new worker has been added to the cluster.',
   'clusters.addworker.message.success_multiple':

--- a/src/locales/ja-JP/clusters.ts
+++ b/src/locales/ja-JP/clusters.ts
@@ -111,6 +111,7 @@ export default {
     'e.g. /data/cache (path must start with /)',
   'clusters.addworker.vendorNotes.title': 'Notes for {vendor} Device',
   'clusters.addworker.amdNotes-01': `If the <span class="bold-text">/opt/rocm</span> directory does not exist, please create a symbolic link pointing to the ROCm installed path: <span class="bold-text">ln -s /path/to/rocm /opt/rocm</span>.`,
+  'clusters.addworker.amdNotes-02': `ホスト上で複数の ROCm バージョンを管理している場合、検出の失敗を避けるために <span class="bold-text">/opt/rocm/lib</span> をマウントする必要があります。`,
   'clusters.addworker.message.success_single':
     '{count} new worker has been added to the cluster.',
   'clusters.addworker.message.success_multiple':

--- a/src/locales/ru-RU/clusters.ts
+++ b/src/locales/ru-RU/clusters.ts
@@ -111,6 +111,7 @@ export default {
     'e.g. /data/cache (path must start with /)',
   'clusters.addworker.vendorNotes.title': 'Примечания для устройств {vendor}',
   'clusters.addworker.amdNotes-01': `Если директория <span class="bold-text">/opt/rocm</span> не существует, создайте символическую ссылку на путь установки ROCm: <span class="bold-text">ln -s /путь/к/rocm /opt/rocm</span>.`,
+  'clusters.addworker.amdNotes-02': `Если на хосте управляется несколько версий ROCm, необходимо смонтировать <span class="bold-text">/opt/rocm/lib</span>, чтобы избежать сбоев обнаружения устройств.`,
   'clusters.addworker.message.success_single':
     '{count} новый воркер был добавлен в кластер.',
   'clusters.addworker.message.success_multiple':

--- a/src/locales/tr-TR/clusters.ts
+++ b/src/locales/tr-TR/clusters.ts
@@ -111,6 +111,7 @@ export default {
     'örn. /data/cache (yol / ile başlamalıdır)',
   'clusters.addworker.vendorNotes.title': '{vendor} Cihaz Notları',
   'clusters.addworker.amdNotes-01': `<span class="bold-text">/opt/rocm</span> dizini mevcut değilse, lütfen ROCm kurulum yoluna işaret eden sembolik bağlantı oluşturun: <span class="bold-text">ln -s /path/to/rocm /opt/rocm</span>.`,
+  'clusters.addworker.amdNotes-02': `Ana makinede birden fazla ROCm sürümü yönetiliyorsa, algılama hatalarını önlemek için <span class="bold-text">/opt/rocm/lib</span> dizinini bağlamanız gerekir.`,
   'clusters.addworker.message.success_single':
     '{count} yeni işçi düğüm kümeye eklendi.',
   'clusters.addworker.message.success_multiple':

--- a/src/locales/zh-CN/clusters.ts
+++ b/src/locales/zh-CN/clusters.ts
@@ -109,6 +109,7 @@ export default {
   'clusters.addworker.vendorNotes.title': '{vendor}设备注意事项',
   'clusters.addworker.amdNotes-01': `如果 <span class="bold-text">/opt/rocm</span> 目录不存在，请创建一个指向已安装 ROCm 路径的符号链接：
     <span class="bold-text">ln -s /path/to/rocm /opt/rocm</span>。`,
+  'clusters.addworker.amdNotes-02': `如果主机上管理了多个 ROCm 版本，必须挂载 <span class="bold-text">/opt/rocm/lib</span>，以避免设备检测失败。`,
   'clusters.addworker.message.success_single':
     '已将 {count} 个新节点添加到集群中。',
   'clusters.addworker.message.success_multiple':

--- a/src/pages/resources/config/gpu-driver.ts
+++ b/src/pages/resources/config/gpu-driver.ts
@@ -341,6 +341,7 @@ const registerAMDWorker = (params: AddWorkerCommandParams) => {
   // remove empty enter lines and trailing backslash
   return `${commonArgs}
       --volume /opt/rocm:/opt/rocm:ro \\
+      --volume /opt/rocm/lib:/opt/rocm/lib:ro \\
       --runtime ${config.runtime} \\
       ${imageArgs}
       ${setWorkerIPArg(params)}`;
@@ -451,7 +452,10 @@ export const registerAddWokerCommandMap = {
 
 export const AddWorkerDockerNotes: Record<string, string[]> = {
   [GPUDriverMap.NVIDIA]: ['clusters.addworker.nvidiaNotes'],
-  [GPUDriverMap.AMD]: ['clusters.addworker.amdNotes-01'],
+  [GPUDriverMap.AMD]: [
+    'clusters.addworker.amdNotes-01',
+    'clusters.addworker.amdNotes-02'
+  ],
   [GPUDriverMap.MOORE_THREADS]: [],
   [GPUDriverMap.ASCEND]: [],
   [GPUDriverMap.HYGON]: [


### PR DESCRIPTION
Hosts managing multiple ROCm versions need the lib directory mounted explicitly, or device detection fails.