### PR TITLE
feat(kv-cache): ask for an image when the provider declares no version

### DIFF
--- a/src/locales/en-US/kv-cache.ts
+++ b/src/locales/en-US/kv-cache.ts
@@ -54,6 +54,7 @@ export default {
   'kvCache.form.l2Backend.add': 'Add Backend',
   'kvCache.form.l2Backend.backend': 'Backend',
   'kvCache.form.l2Backend.type': 'Type',
+  'kvCache.form.l2Backend.customOptions': 'Custom Options',
   'kvCache.form.l2Backend.tips':
     'Spill KV cache to larger secondary storage tiers. Entries are prioritized in order: reads prefer the first; writes go to all.',
   'kvCache.form.metricsPort': 'Metrics Port (Prometheus)',

--- a/src/locales/ja-JP/kv-cache.ts
+++ b/src/locales/ja-JP/kv-cache.ts
@@ -54,6 +54,7 @@ export default {
   'kvCache.form.l2Backend.add': 'Add Backend',
   'kvCache.form.l2Backend.backend': 'Backend',
   'kvCache.form.l2Backend.type': 'Type',
+  'kvCache.form.l2Backend.customOptions': 'Custom Options',
   'kvCache.form.l2Backend.tips':
     'Spill KV cache to larger secondary storage tiers. Entries are prioritized in order: reads prefer the first; writes go to all.',
   'kvCache.form.metricsPort': 'Metrics Port (Prometheus)',

--- a/src/locales/ru-RU/kv-cache.ts
+++ b/src/locales/ru-RU/kv-cache.ts
@@ -54,6 +54,7 @@ export default {
   'kvCache.form.l2Backend.add': 'Add Backend',
   'kvCache.form.l2Backend.backend': 'Backend',
   'kvCache.form.l2Backend.type': 'Type',
+  'kvCache.form.l2Backend.customOptions': 'Custom Options',
   'kvCache.form.l2Backend.tips':
     'Spill KV cache to larger secondary storage tiers. Entries are prioritized in order: reads prefer the first; writes go to all.',
   'kvCache.form.metricsPort': 'Metrics Port (Prometheus)',

--- a/src/locales/tr-TR/kv-cache.ts
+++ b/src/locales/tr-TR/kv-cache.ts
@@ -55,6 +55,7 @@ export default {
   'kvCache.form.l2Backend.add': 'Altyapı Ekle',
   'kvCache.form.l2Backend.backend': 'Backend',
   'kvCache.form.l2Backend.type': 'Type',
+  'kvCache.form.l2Backend.customOptions': 'Custom Options',
   'kvCache.form.l2Backend.tips':
     'KV önbelleğini daha büyük ikincil depolama katmanlarına taşırır. Girdiler sırayla önceliklendirilir: okumalar ilkini tercih eder, yazmalar hepsine gider.',
   'kvCache.form.metricsPort': 'Metrik Bağlantı Noktası (Prometheus)',

--- a/src/locales/zh-CN/kv-cache.ts
+++ b/src/locales/zh-CN/kv-cache.ts
@@ -51,6 +51,7 @@ export default {
   'kvCache.form.l2Backend.add': '添加后端',
   'kvCache.form.l2Backend.backend': '后端',
   'kvCache.form.l2Backend.type': '类型',
+  'kvCache.form.l2Backend.customOptions': '自定义配置',
   'kvCache.form.l2Backend.tips':
     '将 KV 缓存下沉到容量更大的二级存储。条目按顺序生效:读取优先第一个,写入落所有后端。',
   'kvCache.form.metricsPort': '监控端口 (Prometheus)',

--- a/src/pages/kv-cache/components/provider-catalog.tsx
+++ b/src/pages/kv-cache/components/provider-catalog.tsx
@@ -46,10 +46,12 @@ const ProviderCard: React.FC<{
   const intl = useIntl();
 
   // accelerator families the provider declares dedicated builds for
-  // (runtime_images doubles as the support matrix). Managed only: an
+  // (runtime_images doubles as the support matrix). A provider that
+  // publishes no image declares no matrix, so the claim falls back to
+  // the accelerators its engine integrations are scoped to — the gate
+  // that decides whether an engine can attach at all. Managed only: an
   // external provider runs no platform container, so the claim would be
-  // meaningless; a managed provider without runtime_images makes no
-  // accelerator-specific claim and shows nothing.
+  // meaningless; a provider declaring neither shows nothing.
   const frameworks = useMemo(() => {
     if (!data.supported_modes?.includes('managed')) {
       return [];
@@ -60,6 +62,11 @@ const ProviderCard: React.FC<{
         names.add(name)
       );
     });
+    if (!names.size) {
+      (data.inference_backend_integrations || []).forEach((integration) =>
+        (integration.frameworks || []).forEach((name) => names.add(name))
+      );
+    }
     return Array.from(names);
   }, [data]);
 

--- a/src/pages/kv-cache/config/index.ts
+++ b/src/pages/kv-cache/config/index.ts
@@ -83,8 +83,8 @@ export const canViewInstanceLogs = (instance: CacheServiceInstanceItem) =>
 export const isHttpUrl = (url?: string | null): boolean =>
   !!url && /^https?:\/\//i.test(url);
 
-// The reserved "custom" version says nothing by itself, so it is shown with
-// the image the service actually runs.
+// The reserved "custom" version names no release, so the image the
+// service actually runs stands in for it.
 export const formatServiceVersion = (
   providerVersion?: string,
   image?: string
@@ -92,9 +92,7 @@ export const formatServiceVersion = (
   if (!providerVersion) {
     return '';
   }
-  return providerVersion === 'custom' && image
-    ? `${providerVersion} (${image})`
-    : providerVersion;
+  return providerVersion === 'custom' && image ? image : providerVersion;
 };
 
 // actions for an instance row: logs when the state can have any, and

--- a/src/pages/kv-cache/config/types.ts
+++ b/src/pages/kv-cache/config/types.ts
@@ -31,6 +31,11 @@ export interface CacheProviderL2Backend {
   display_name?: string;
   description?: string;
   icon?: string;
+  // when set, configuring this backend is optional: the form offers a
+  // switch, and the declared fields only apply while it is on
+  adapter_flag_optional?: boolean;
+  adapter_flag_default?: boolean;
+  adapter_flag_label?: string;
   fields: CacheProviderL2Field[];
 }
 
@@ -122,6 +127,9 @@ export interface CacheProviderItem {
 export interface L2StorageConfig {
   backend: string;
   params: Record<string, any>;
+  // state of the backend's optional-configuration switch; absent for
+  // backends that declare none
+  adapter_flag_enabled?: boolean;
 }
 
 export interface ServiceEndpoint {

--- a/src/pages/kv-cache/forms/index.tsx
+++ b/src/pages/kv-cache/forms/index.tsx
@@ -40,6 +40,7 @@ import { ServiceModeValueMap } from '../config';
 import {
   CacheProviderExternalField,
   CacheProviderField,
+  CacheProviderL2Backend,
   CacheProviderL2Field,
   FormData,
   L2StorageConfig,
@@ -423,6 +424,15 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
     return options;
   }, [providers, providerName, isManaged, intl]);
 
+  // a provider whose image is not published declares no release line at
+  // all: there is no version to pick, and the service names its image
+  // under the reserved "custom" version instead
+  const hasDeclaredVersions = useMemo(() => {
+    return Boolean(
+      Object.keys(getProvider(providerName)?.versions || {}).length
+    );
+  }, [getProvider, providerName]);
+
   // the provider's pinned default image doubles as a format hint for
   // the custom image input
   const defaultImage = useMemo(() => {
@@ -464,7 +474,13 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
   // provider set either way carries its default version and a clean L2 config
   const applyProviderSelection = (value: string) => {
     const provider = getProvider(value);
-    form.setFieldValue('provider_version', provider?.default_version);
+    // with no declared version to fall back to, the service runs its own
+    // image under the reserved "custom" version
+    form.setFieldValue(
+      'provider_version',
+      provider?.default_version ??
+        (provider?.custom_version ? 'custom' : undefined)
+    );
     // config.image only accompanies the reserved "custom" version, and
     // the version just reset to the provider default
     form.setFieldValue(['config', 'image'], undefined);
@@ -525,16 +541,44 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
     setL2CollapseKeys(open ? new Set([key]) : new Set());
   };
 
+  // the switch position a backend starts on, and the one the cache server
+  // runs with while an entry leaves the state unset (saved by the API, or
+  // before the backend declared the switch)
+  const l2ConfigDefault = (spec?: CacheProviderL2Backend) =>
+    spec?.adapter_flag_default !== false;
+
+  // a backend's declared starting state: its field defaults, plus the
+  // initial position of the switch when configuring it is optional
+  const seedL2Entry = (backend: string) => {
+    const spec = l2Backends[backend];
+    const params: Record<string, any> = {};
+    spec?.fields?.forEach((field) => {
+      if (field.default !== undefined) {
+        params[field.name] = field.default;
+      }
+    });
+    return {
+      params,
+      adapter_flag_enabled: spec?.adapter_flag_optional
+        ? l2ConfigDefault(spec)
+        : undefined
+    };
+  };
+
   const handleAddL2Storage = async () => {
     try {
       await form.validateFields([['config', 'l2_storages']], {
         recursive: true
       });
       const list = form.getFieldValue(['config', 'l2_storages']) || [];
-      form.setFieldValue(
-        ['config', 'l2_storages'],
-        [...list, { backend: undefined, params: {} }]
-      );
+      // a provider declaring a single backend leaves nothing to choose:
+      // the new entry opens on it, seeded as a manual pick would be
+      const backendKeys = Object.keys(l2Backends);
+      const entry =
+        backendKeys.length === 1
+          ? { backend: backendKeys[0], ...seedL2Entry(backendKeys[0]) }
+          : { backend: undefined, params: {} };
+      form.setFieldValue(['config', 'l2_storages'], [...list, entry]);
       setTimeout(() => {
         setL2CollapseKeys(new Set([list.length]));
       }, 100);
@@ -582,15 +626,14 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
   };
 
   const handleL2BackendChange = (index: number, value: string) => {
-    // params are backend-specific; reseed this entry from the newly
-    // selected backend's declared defaults
-    const params: Record<string, any> = {};
-    l2Backends[value]?.fields?.forEach((field) => {
-      if (field.default !== undefined) {
-        params[field.name] = field.default;
-      }
-    });
+    // params and the switch are backend-specific; reseed this entry from
+    // the newly selected backend's declared defaults
+    const { params, adapter_flag_enabled } = seedL2Entry(value);
     form.setFieldValue(['config', 'l2_storages', index, 'params'], params);
+    form.setFieldValue(
+      ['config', 'l2_storages', index, 'adapter_flag_enabled'],
+      adapter_flag_enabled
+    );
   };
 
   // provider-declared configuration knobs promoted to structured advanced
@@ -773,6 +816,28 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
     applyProviderSelection(preset);
   }, [providerOptions, action, provider]);
 
+  // a provider with no declared release line only ever runs the custom
+  // version, so any other value the form holds — an existing service
+  // pinned to a version the catalog has since dropped, or a creation that
+  // never reached the provider defaults — leaves it with neither a
+  // version to pick nor the image field that replaces it
+  useEffect(() => {
+    if (!isManaged || hasDeclaredVersions || providerVersion === 'custom') {
+      return;
+    }
+    if (!getProvider(providerName)?.custom_version) {
+      return;
+    }
+    form.setFieldValue('provider_version', 'custom');
+  }, [
+    form,
+    isManaged,
+    hasDeclaredVersions,
+    providerVersion,
+    providerName,
+    getProvider
+  ]);
+
   // with a single cluster there is nothing to choose; preselect it
   // re-runs on a provider switch too: stepping back and picking a
   // different card resets the form, which empties cluster_id
@@ -891,7 +956,14 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
         />
       </Form.Item>
       {isManaged && (
-        <Form.Item<FormData> name="provider_version">
+        // A provider with no declared release line has no version to pick,
+        // but the field stays registered: an unmounted one is absent from
+        // both the watched values and the submit payload, and the image
+        // field below keys on it.
+        <Form.Item<FormData>
+          name="provider_version"
+          hidden={!hasDeclaredVersions}
+        >
           <SealSelect
             options={versionOptions}
             onChange={handleVersionChange}
@@ -1173,37 +1245,65 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
                                 description={entryBackend?.description}
                               />
                             </Form.Item>
-                            {entryBackend?.fields?.map((field) => {
-                              const label =
-                                field.label || humanizeFieldName(field.name);
-                              const isBoolean = field.type === 'boolean';
-                              return (
-                                <Form.Item
-                                  // remount per backend so same-named params never leak across backends
-                                  key={`${entryBackendName}-${field.name}`}
-                                  name={[name, 'params', field.name]}
-                                  valuePropName={
-                                    isBoolean ? 'checked' : 'value'
+                            {entryBackend?.adapter_flag_optional && (
+                              <Form.Item
+                                // remount per backend: the switch belongs
+                                // to the backend that declared it
+                                key={`${entryBackendName}-adapter-flag`}
+                                name={[name, 'adapter_flag_enabled']}
+                                valuePropName="checked"
+                                getValueProps={(value) => ({
+                                  checked:
+                                    value ?? l2ConfigDefault(entryBackend)
+                                })}
+                              >
+                                <CheckboxField
+                                  label={
+                                    entryBackend.adapter_flag_label ||
+                                    intl.formatMessage({
+                                      id: 'kvCache.form.l2Backend.customOptions'
+                                    })
                                   }
-                                  rules={
-                                    field.required && !isBoolean
-                                      ? [
-                                          {
-                                            required: true,
-                                            message: getRuleMessage(
-                                              'input',
-                                              label,
-                                              false
-                                            )
-                                          }
-                                        ]
-                                      : []
-                                  }
-                                >
-                                  {renderL2FieldControl(field, label)}
-                                </Form.Item>
-                              );
-                            })}
+                                />
+                              </Form.Item>
+                            )}
+                            {/* the backend carries a working configuration
+                                of its own while the switch is off, and the
+                                fields have nothing to apply to */}
+                            {(!entryBackend?.adapter_flag_optional ||
+                              (l2Storages?.[name]?.adapter_flag_enabled ??
+                                l2ConfigDefault(entryBackend))) &&
+                              entryBackend?.fields?.map((field) => {
+                                const label =
+                                  field.label || humanizeFieldName(field.name);
+                                const isBoolean = field.type === 'boolean';
+                                return (
+                                  <Form.Item
+                                    // remount per backend so same-named params never leak across backends
+                                    key={`${entryBackendName}-${field.name}`}
+                                    name={[name, 'params', field.name]}
+                                    valuePropName={
+                                      isBoolean ? 'checked' : 'value'
+                                    }
+                                    rules={
+                                      field.required && !isBoolean
+                                        ? [
+                                            {
+                                              required: true,
+                                              message: getRuleMessage(
+                                                'input',
+                                                label,
+                                                false
+                                              )
+                                            }
+                                          ]
+                                        : []
+                                    }
+                                  >
+                                    {renderL2FieldControl(field, label)}
+                                  </Form.Item>
+                                );
+                              })}
                           </CollapseContainer>
                         </div>
                       );


### PR DESCRIPTION
A provider whose image is not published declares no release line, so the service form drops the version select and takes the image directly under the reserved custom version — shown in place of "custom" wherever the service's version is displayed. Its catalog card falls back to the accelerators its engine integrations are scoped to, the claim it still declares once there is no image matrix to read one from.

L2 storage follows the same declaration-shaped rules: a provider with a single declared backend opens new entries on it, and a backend that marks its configuration optional now renders the switch the catalog declares, hiding its fields while off.