### PR TITLE
feat(kv-cache): resolve localized text from the provider catalog

### DIFF
--- a/src/pages/kv-cache/components/provider-catalog.tsx
+++ b/src/pages/kv-cache/components/provider-catalog.tsx
@@ -1,4 +1,5 @@
 import { getGpuColor } from '@/pages/backends/config';
+import { localize } from '@/utils/localize';
 import { AutoTooltip, IconFont, ThemeTag } from '@gpustack/core-ui';
 import { useIntl } from '@umijs/max';
 import { Flex, Typography } from 'antd';
@@ -83,7 +84,9 @@ const ProviderCard: React.FC<{
             <IconFont type="icon-storage-outlined" className="fallback-icon" />
           )}
         </span>
-        <AutoTooltip ghost>{data.display_name || data.name}</AutoTooltip>
+        <AutoTooltip ghost>
+          {localize(data.display_name) || data.name}
+        </AutoTooltip>
         {ProviderSourceLabelMap[data.source] && (
           <ThemeTag
             className="tag-item"
@@ -112,12 +115,12 @@ const ProviderCard: React.FC<{
                 overflow: 'auto'
               }}
             >
-              {data.description}
+              {localize(data.description)}
             </div>
           )
         }}
       >
-        {data.description}
+        {localize(data.description)}
       </Typography.Paragraph>
       {frameworks.length > 0 && (
         <div className="frameworks">
@@ -162,7 +165,7 @@ const ProviderCard: React.FC<{
               rel="noopener noreferrer"
               onClick={(e) => e.stopPropagation()}
             >
-              {link.label}
+              {localize(link.label)}
               <IconFont type="icon-external-link"></IconFont>
             </a>
           ))}

--- a/src/pages/kv-cache/components/service-overview.tsx
+++ b/src/pages/kv-cache/components/service-overview.tsx
@@ -1,3 +1,4 @@
+import { localize } from '@/utils/localize';
 import { ExportOutlined } from '@ant-design/icons';
 import {
   AutoTooltip,
@@ -128,7 +129,7 @@ const ServiceOverview: React.FC<ServiceOverviewProps> = ({
       key: 'provider',
       label: intl.formatMessage({ id: 'kvCache.table.provider' }),
       children: [
-        provider?.display_name || data.provider_name,
+        localize(provider?.display_name) || data.provider_name,
         formatServiceVersion(data.provider_version, data.config?.image)
       ]
         .filter(Boolean)

--- a/src/pages/kv-cache/config/types.ts
+++ b/src/pages/kv-cache/config/types.ts
@@ -1,3 +1,5 @@
+import type { LocalizedText } from '@/utils/localize';
+
 export type ServiceMode = 'managed' | 'external';
 
 export type ServiceState =
@@ -20,7 +22,7 @@ export interface CacheProviderVersionConfig {
 export interface CacheProviderL2Field {
   // provider-defined technical key; humanized as the label fallback
   name: string;
-  label?: string;
+  label?: LocalizedText;
   type?: 'string' | 'number' | 'boolean' | 'password';
   required?: boolean;
   default?: any;
@@ -28,14 +30,14 @@ export interface CacheProviderL2Field {
 }
 
 export interface CacheProviderL2Backend {
-  display_name?: string;
-  description?: string;
+  display_name?: LocalizedText;
+  description?: LocalizedText;
   icon?: string;
   // when set, configuring this backend is optional: the form offers a
   // switch, and the declared fields only apply while it is on
   adapter_flag_optional?: boolean;
   adapter_flag_default?: boolean;
-  adapter_flag_label?: string;
+  adapter_flag_label?: LocalizedText;
   fields: CacheProviderL2Field[];
 }
 
@@ -44,18 +46,20 @@ export interface CacheProviderL2Backend {
 // connector injection server-side
 export interface CacheProviderExternalField {
   name: string;
-  label?: string;
-  description?: string;
+  label?: LocalizedText;
+  description?: LocalizedText;
   type?: 'string' | 'number' | 'boolean' | 'password';
   required?: boolean;
   default?: any;
-  // when set, the field is a fixed choice (e.g. protocol tcp/rdma)
+  // when set, the field is a fixed choice (e.g. protocol tcp/rdma); the
+  // values are the engine's own enum and reach it verbatim, so they are
+  // never localized — their meaning belongs in the field description
   options?: string[];
 }
 
 // brand link (docs, homepage) shown on the provider card
 export interface CacheProviderLink {
-  label: string;
+  label: LocalizedText;
   url: string;
 }
 
@@ -65,8 +69,8 @@ export interface CacheProviderLink {
 // parameters still override any flag they produce)
 export interface CacheProviderField {
   name: string;
-  label?: string;
-  description?: string;
+  label?: LocalizedText;
+  description?: LocalizedText;
   type?: 'string' | 'number' | 'boolean';
   default?: any;
   options?: string[];
@@ -78,9 +82,9 @@ export interface CacheProviderField {
 
 export interface CacheProviderItem {
   name: string;
-  display_name: string;
+  display_name: LocalizedText;
   source: 'built_in' | 'community' | 'partner';
-  description?: string;
+  description?: LocalizedText;
   icon?: string;
   links?: CacheProviderLink[];
   supported_modes: ServiceMode[];

--- a/src/pages/kv-cache/detail.tsx
+++ b/src/pages/kv-cache/detail.tsx
@@ -1,3 +1,4 @@
+import { localize } from '@/utils/localize';
 import { BaseSelect, DeleteModal, useQueryDataList } from '@gpustack/core-ui';
 import { useIntl, useNavigate, useSearchParams } from '@umijs/max';
 import { useMemoizedFn } from 'ahooks';
@@ -56,7 +57,7 @@ const CacheServiceDetail: React.FC = () => {
     const names: Record<string, string> = {};
     (detailData?.config?.l2_storages || []).forEach((storage) => {
       names[storage.backend] =
-        provider?.l2_backends?.[storage.backend]?.display_name ||
+        localize(provider?.l2_backends?.[storage.backend]?.display_name) ||
         storage.backend;
     });
     return names;

--- a/src/pages/kv-cache/forms/index.tsx
+++ b/src/pages/kv-cache/forms/index.tsx
@@ -3,6 +3,7 @@ import { PageActionType } from '@/config/types';
 import { useQueryClusterList } from '@/pages/cluster-management/services/use-query-cluster-list';
 import { ListItem as WorkerListItem } from '@/pages/resources/config/types';
 import { useQueryWorkerList } from '@/pages/resources/services/use-query-worker-list';
+import { localize } from '@/utils/localize';
 import {
   ArrowDownOutlined,
   ArrowUpOutlined,
@@ -464,7 +465,7 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
 
   const l2BackendOptions = useMemo(() => {
     return Object.entries(l2Backends).map(([key, backend]) => ({
-      label: backend.display_name || key,
+      label: localize(backend.display_name) || key,
       value: key,
       icon: backend.icon
     }));
@@ -646,7 +647,7 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
     field: CacheProviderField,
     label: string
   ) => {
-    const description = field.description;
+    const description = localize(field.description);
     if (field.options?.length) {
       return (
         <SealSelect
@@ -697,7 +698,7 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
     field: CacheProviderExternalField,
     label: string
   ) => {
-    const description = field.description;
+    const description = localize(field.description);
     if (field.options?.length) {
       return (
         <SealSelect
@@ -1097,7 +1098,7 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
             >
               {renderProviderFieldControl(
                 field,
-                field.label || humanizeFieldName(field.name)
+                localize(field.label) || humanizeFieldName(field.name)
               )}
             </Form.Item>
           ))}
@@ -1159,7 +1160,7 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
                             title={
                               <EntryTitle>
                                 <span>
-                                  {entryBackend?.display_name ||
+                                  {localize(entryBackend?.display_name) ||
                                     entryBackendName ||
                                     intl.formatMessage({
                                       id: 'kvCache.form.l2Backend.backend'
@@ -1242,7 +1243,9 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
                                 label={intl.formatMessage({
                                   id: 'kvCache.form.l2Backend.type'
                                 })}
-                                description={entryBackend?.description}
+                                description={localize(
+                                  entryBackend?.description
+                                )}
                               />
                             </Form.Item>
                             {entryBackend?.adapter_flag_optional && (
@@ -1259,7 +1262,7 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
                               >
                                 <CheckboxField
                                   label={
-                                    entryBackend.adapter_flag_label ||
+                                    localize(entryBackend.adapter_flag_label) ||
                                     intl.formatMessage({
                                       id: 'kvCache.form.l2Backend.customOptions'
                                     })
@@ -1275,7 +1278,8 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
                                 l2ConfigDefault(entryBackend))) &&
                               entryBackend?.fields?.map((field) => {
                                 const label =
-                                  field.label || humanizeFieldName(field.name);
+                                  localize(field.label) ||
+                                  humanizeFieldName(field.name);
                                 const isBoolean = field.type === 'boolean';
                                 return (
                                   <Form.Item
@@ -1460,7 +1464,8 @@ const ServiceForm: React.FC<ServiceFormProps> = forwardRef((props, ref) => {
             />
           </Form.Item>
           {externalFields.map((field) => {
-            const label = field.label || humanizeFieldName(field.name);
+            const label =
+              localize(field.label) || humanizeFieldName(field.name);
             const isBoolean = field.type === 'boolean';
             return (
               <Form.Item

--- a/src/pages/kv-cache/hooks/use-cache-providers.ts
+++ b/src/pages/kv-cache/hooks/use-cache-providers.ts
@@ -1,11 +1,14 @@
+import { localize } from '@/utils/localize';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { queryCacheProviders } from '../apis';
 import { ServiceModeValueMap } from '../config';
 import { CacheProviderItem, ServiceMode } from '../config/types';
 
+// The option label is display text only; value stays the catalog name,
+// so what a form submits does not move with the user's locale.
 const toOption = (item: CacheProviderItem) => ({
   ...item,
-  label: item.display_name || item.name,
+  label: localize(item.display_name) || item.name,
   value: item.name
 });
 

--- a/src/pages/kv-cache/hooks/use-service-columns.tsx
+++ b/src/pages/kv-cache/hooks/use-service-columns.tsx
@@ -2,6 +2,7 @@ import { ExportOutlined } from '@ant-design/icons';
 // columns.ts
 import { systemConfigAtom } from '@/atoms/system';
 import { tableSorter } from '@/config/settings';
+import { localize } from '@/utils/localize';
 import {
   AutoTooltip,
   DropdownButtons,
@@ -66,7 +67,7 @@ const useServiceColumns = (
             <IconFont type="icon-storage-outlined" />
           )}
           <AutoTooltip ghost minWidth={20}>
-            {provider?.display_name || value}
+            {localize(provider?.display_name) || value}
           </AutoTooltip>
         </div>
       );

--- a/src/utils/localize.ts
+++ b/src/utils/localize.ts
@@ -1,0 +1,31 @@
+import { getLocale } from '@umijs/max';
+
+/**
+ * A user-facing string served by a declarative catalog, either bare or
+ * keyed by locale. The backend serves the mapping as declared: the
+ * request carries no reliable signal of the locale the user picked in
+ * the UI, so resolution happens here.
+ */
+export type LocalizedText = string | Record<string, string>;
+
+/**
+ * Resolve a localized string against the active locale, widening to the
+ * base language before falling back to the declaration's canonical text.
+ * A locale the catalog does not translate reads as the author wrote it
+ * rather than as a blank.
+ */
+export const localize = (value?: LocalizedText | null): string | undefined => {
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  const locale = getLocale();
+  return (
+    value[locale] ??
+    value[locale.split('-')[0]] ??
+    value.default ??
+    Object.values(value)[0]
+  );
+};


### PR DESCRIPTION
Backend PR: https://github.com/gpustack/gpustack/pull/6170

Server-side counterpart is gpustack eee47d0a, which made the cache-provider catalog's display slots take either a bare string or a mapping keyed by locale. A partner declaration is the one place user-facing copy arrives from outside this repo, so it cannot go through the locale files the rest of the UI uses -- and the API cannot resolve it either, since the locale is a preference the user picks here and the request carries no reliable signal of it.

localize() takes the active locale, widens to the base language, then falls back to the declaration's "default" entry, so a locale the catalog does not translate reads as the author wrote it rather than as a blank. A bare string passes through untouched, which is every declaration written so far.

Applied at the fifteen sites that render catalog text: the provider card, the service table and overview, and the managed and external field forms. Where a label falls back to a humanized field name, the fallback chain still runs -- localize() returns undefined rather than an object.

Options values and the provider name an option carries as its value stay untouched. Those are identity: the first reaches the engine verbatim, the second is what the form submits, and neither may move with the user's locale.